### PR TITLE
counts/matches fixes

### DIFF
--- a/src/actions/player/playerMatchesActions.js
+++ b/src/actions/player/playerMatchesActions.js
@@ -1,9 +1,9 @@
 import fetch from 'isomorphic-fetch';
 import {
-  API_HOST
+  API_HOST,
 } from 'config';
 import {
-  playerMatches
+  playerMatches,
 } from 'reducers';
 import {
   getUrl,
@@ -33,7 +33,7 @@ export const setPlayerMatchesSort = (sortField, sortState, sortFn, id) => ({
 
 export const getPlayerMatchesRequest = (id) => ({
   type: REQUEST,
-  id
+  id,
 });
 
 export const getPlayerMatchesOk = (payload, id) => ({
@@ -49,7 +49,7 @@ export const getPlayerMatchesError = (payload, id) => ({
 });
 
 const defaultOptions = {
-  project: ['hero_id', 'start_time', 'duration', 'player_slot', 'radiant_win', 'game_mode', 'version', 'kills', 'deaths', 'assists', 'skill']
+  project: ['hero_id', 'start_time', 'duration', 'player_slot', 'radiant_win', 'game_mode', 'version', 'kills', 'deaths', 'assists', 'skill'],
 };
 
 export const getPlayerMatches = (playerId, options = {}, host = API_HOST) => (dispatch, getState) => {
@@ -60,8 +60,8 @@ export const getPlayerMatches = (playerId, options = {}, host = API_HOST) => (di
     dispatch(getPlayerMatchesRequest(playerId));
   }
   return fetch(`${host}${getUrl(playerId, modifiedOptions, url)}`, {
-      credentials: 'include'
-    })
+    credentials: 'include',
+  })
     .then(response => response.json())
     .then(json => dispatch(getPlayerMatchesOk(json, playerId)))
     .catch(error => dispatch(getPlayerMatchesError(error, playerId)));

--- a/src/actions/player/playerMatchesActions.js
+++ b/src/actions/player/playerMatchesActions.js
@@ -1,7 +1,13 @@
 import fetch from 'isomorphic-fetch';
-import { API_HOST } from 'config';
-import { playerMatches } from 'reducers';
-import { getUrl, defaultOptions } from 'actions/utility';
+import {
+  API_HOST
+} from 'config';
+import {
+  playerMatches
+} from 'reducers';
+import {
+  getUrl,
+} from 'actions/utility';
 
 const url = playerId => `/api/players/${playerId}/matches`;
 
@@ -25,7 +31,10 @@ export const setPlayerMatchesSort = (sortField, sortState, sortFn, id) => ({
   id,
 });
 
-export const getPlayerMatchesRequest = (id) => ({ type: REQUEST, id });
+export const getPlayerMatchesRequest = (id) => ({
+  type: REQUEST,
+  id
+});
 
 export const getPlayerMatchesOk = (payload, id) => ({
   type: OK,
@@ -39,16 +48,20 @@ export const getPlayerMatchesError = (payload, id) => ({
   id,
 });
 
+const defaultOptions = {
+  project: ['hero_id', 'start_time', 'duration', 'player_slot', 'radiant_win', 'game_mode', 'version', 'kills', 'deaths', 'assists', 'skill']
+};
+
 export const getPlayerMatches = (playerId, options = {}, host = API_HOST) => (dispatch, getState) => {
-  let modifiedOptions = options;
-  if (Object.keys(options).length === 0) modifiedOptions = defaultOptions;
+  const modifiedOptions = Object.assign({}, defaultOptions, options);
   if (playerMatches.isLoaded(getState(), playerId)) {
     dispatch(getPlayerMatchesOk(playerMatches.getMatchList(getState(), playerId), playerId));
   } else {
     dispatch(getPlayerMatchesRequest(playerId));
   }
-  modifiedOptions.project = ['skill'].concat(modifiedOptions.project || []);
-  return fetch(`${host}${getUrl(playerId, modifiedOptions, url)}`, { credentials: 'include' })
+  return fetch(`${host}${getUrl(playerId, modifiedOptions, url)}`, {
+      credentials: 'include'
+    })
     .then(response => response.json())
     .then(json => dispatch(getPlayerMatchesOk(json, playerId)))
     .catch(error => dispatch(getPlayerMatchesError(error, playerId)));

--- a/src/actions/utility.js
+++ b/src/actions/utility.js
@@ -4,10 +4,6 @@ import querystring from 'querystring';
 export const getUrl = (playerId, options, url) =>
   `${url(playerId)}?${querystring.stringify(options)}`;
 
-export const defaultOptions = {
-  limit: [20],
-};
-
 export const getModifiedOptions = (options, excludedOptions) => {
   const modifiedOptions = {};
   Object.keys(options).forEach(key => {

--- a/src/components/Explorer/queries.js
+++ b/src/components/Explorer/queries.js
@@ -1,5 +1,5 @@
 /* eslint-disable */
-module.exports = {
+export default {
   'players':
   {
     'name': 'Players',

--- a/src/components/Footer/Cheese.jsx
+++ b/src/components/Footer/Cheese.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router';
 import { Row, Col } from 'react-flexbox-grid';
-import strings from 'lang/en';
+import strings from 'lang';
 // import EditorAttachMoney from 'material-ui/svg-icons/editor/attach-money';
 import CheeseCircle from '../Cheese';
 // import styles from './Footer.css';

--- a/src/components/Footer/Links.jsx
+++ b/src/components/Footer/Links.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import IconButton from 'material-ui/IconButton';
-import strings from 'lang/en';
+import strings from 'lang';
 import styles from './Footer.css';
 import { IconSteam } from '../Icons';
 

--- a/src/components/Footer/SocialLinks.jsx
+++ b/src/components/Footer/SocialLinks.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import IconButton from 'material-ui/IconButton';
-import strings from 'lang/en';
+import strings from 'lang';
 import { IconGithub, IconTwitter, IconDiscord } from '../Icons';
 import styles from './Footer.css';
 

--- a/src/components/FourOhFour/FourOhFour.jsx
+++ b/src/components/FourOhFour/FourOhFour.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import strings from 'lang/en';
+import strings from 'lang';
 import styles from './FourOhFour.css';
 
 export default () => (

--- a/src/components/Header/Pages.js
+++ b/src/components/Header/Pages.js
@@ -1,4 +1,4 @@
-import strings from 'lang/en';
+import strings from 'lang';
 
 const navbarPages = [{
   name: strings.request,

--- a/src/components/Heroes/BenchmarkTable.jsx
+++ b/src/components/Heroes/BenchmarkTable.jsx
@@ -8,7 +8,7 @@ import {
   TableRowColumn,
 } from 'material-ui/Table';
 
-import strings from 'lang/en.json';
+import strings from 'lang';
 import style from './Heroes.css';
 
 // const alignCenter = { textAlign: 'center' };

--- a/src/components/Match/matchColumns.jsx
+++ b/src/components/Match/matchColumns.jsx
@@ -8,7 +8,7 @@ import {
   ability_ids as abilityIds,
   hero_names as heroNames,
 } from 'dotaconstants';
-import strings from 'lang/en';
+import strings from 'lang';
 import {
   Link,
 } from 'react-router';

--- a/src/components/Player/Pages/Counts/Counts.css
+++ b/src/components/Player/Pages/Counts/Counts.css
@@ -9,8 +9,6 @@
 
 .countsContainer {
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
   flex-wrap: wrap;
-  height: 100vw;
-  margin: 0 -15px;
 }

--- a/src/components/Player/Pages/Counts/playerCountsColumns.jsx
+++ b/src/components/Player/Pages/Counts/playerCountsColumns.jsx
@@ -9,6 +9,7 @@ export default [{
   displayName: strings.th_category,
   field: 'category',
   width: 2,
+  sortFn: true,
   displayFn: transformations.category,
 }, {
   displayName: strings.th_matches,

--- a/src/components/Player/Pages/Counts/playerCountsColumns.jsx
+++ b/src/components/Player/Pages/Counts/playerCountsColumns.jsx
@@ -3,7 +3,7 @@
 import React from 'react';
 import { transformations } from 'utility';
 import { TablePercent } from 'components/Visualizations';
-import strings from 'lang/en';
+import strings from 'lang';
 
 export default [{
   displayName: strings.th_category,

--- a/src/components/Player/Pages/Heroes/playerHeroesColumns.jsx
+++ b/src/components/Player/Pages/Heroes/playerHeroesColumns.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { transformations, getPercentWin } from 'utility';
 import { TablePercent } from 'components/Visualizations';
-import strings from 'lang/en';
+import strings from 'lang';
 
 export const playerHeroesOverviewColumns = [{
   displayName: strings.th_hero,

--- a/src/components/Player/Pages/Matches/Matches.jsx
+++ b/src/components/Player/Pages/Matches/Matches.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
-import { connect } from 'react-redux';
+import {
+  connect
+} from 'react-redux';
 import {
   getPlayerMatches,
   setPlayerMatchesSort,
@@ -8,9 +10,16 @@ import {
   sortPlayerMatches,
   transformPlayerMatchesById,
 } from 'selectors';
-import { playerMatches } from 'reducers';
-import { createTable, TableContainer } from 'components/Table';
-import { TableFilterForm } from 'components/Form';
+import {
+  playerMatches
+} from 'reducers';
+import {
+  createTable,
+  TableContainer
+} from 'components/Table';
+import {
+  TableFilterForm
+} from 'components/Form';
 import playerMatchesColumns from './playerMatchesColumns';
 
 const PlayerMatchesTable = createTable(
@@ -19,7 +28,9 @@ const PlayerMatchesTable = createTable(
   setPlayerMatchesSort
 );
 
-const Matches = ({ playerId }) => (
+const Matches = ({
+  playerId
+}) => (
   <div>
     <TableFilterForm submitAction={getPlayerMatches} id={playerId} page="matches" />
     <TableContainer title="recent matches">
@@ -48,8 +59,12 @@ class RequestLayer extends React.Component {
   }
 }
 
+const defaultOptions = {
+  limit: null
+};
+
 const mapDispatchToProps = (dispatch) => ({
-  getPlayerMatches: (playerId, options) => dispatch(getPlayerMatches(playerId, options)),
+  getPlayerMatches: (playerId, options = defaultOptions) => dispatch(getPlayerMatches(playerId, options)),
 });
 
 export default connect(null, mapDispatchToProps)(RequestLayer);

--- a/src/components/Player/Pages/Matches/Matches.jsx
+++ b/src/components/Player/Pages/Matches/Matches.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {
-  connect
+  connect,
 } from 'react-redux';
 import {
   getPlayerMatches,
@@ -11,14 +11,14 @@ import {
   transformPlayerMatchesById,
 } from 'selectors';
 import {
-  playerMatches
+  playerMatches,
 } from 'reducers';
 import {
   createTable,
-  TableContainer
+  TableContainer,
 } from 'components/Table';
 import {
-  TableFilterForm
+  TableFilterForm,
 } from 'components/Form';
 import playerMatchesColumns from './playerMatchesColumns';
 
@@ -29,7 +29,7 @@ const PlayerMatchesTable = createTable(
 );
 
 const Matches = ({
-  playerId
+  playerId,
 }) => (
   <div>
     <TableFilterForm submitAction={getPlayerMatches} id={playerId} page="matches" />
@@ -60,7 +60,7 @@ class RequestLayer extends React.Component {
 }
 
 const defaultOptions = {
-  limit: null
+  limit: null,
 };
 
 const mapDispatchToProps = (dispatch) => ({

--- a/src/components/Player/Pages/Matches/playerMatchesColumns.jsx
+++ b/src/components/Player/Pages/Matches/playerMatchesColumns.jsx
@@ -1,5 +1,5 @@
 import { transformations } from 'utility';
-import strings from 'lang/en';
+import strings from 'lang';
 
 export default [{
   displayName: strings.th_hero,

--- a/src/components/Player/Pages/Overview/Overview.jsx
+++ b/src/components/Player/Pages/Overview/Overview.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
-import { connect } from 'react-redux';
+import {
+  connect
+} from 'react-redux';
 import {
   getPlayerMatches,
   setPlayerMatchesSort,
@@ -12,11 +14,21 @@ import {
   sortPlayerHeroes,
   transformPlayerHeroesById,
 } from 'selectors';
-import { playerMatches, playerHeroes } from 'reducers';
-import { createTable, TableContainer } from 'components/Table';
-import { TableFilterForm } from 'components/Form';
+import {
+  playerMatches,
+  playerHeroes
+} from 'reducers';
+import {
+  createTable,
+  TableContainer
+} from 'components/Table';
+import {
+  TableFilterForm
+} from 'components/Form';
 import playerMatchesColumns from 'components/Player/Pages/Matches/playerMatchesColumns';
-import { playerHeroesOverviewColumns } from 'components/Player/Pages/Heroes/playerHeroesColumns';
+import {
+  playerHeroesOverviewColumns
+} from 'components/Player/Pages/Heroes/playerHeroesColumns';
 import styles from './Overview.css';
 
 const PlayerMatchesTable = createTable(
@@ -35,7 +47,9 @@ const getPlayerMatchesAndHeroes = (playerId, options) => dispatch => {
   dispatch(getPlayerHeroes(playerId, options));
 };
 
-const Overview = ({ playerId }) => (
+const Overview = ({
+  playerId
+}) => (
   <div>
     <TableFilterForm submitAction={getPlayerMatchesAndHeroes} id={playerId} page="overview" />
     <div className={styles.overviewContainer}>
@@ -70,8 +84,12 @@ class RequestLayer extends React.Component {
   }
 }
 
+const defaultOptions = {
+  limit: [20]
+};
+
 const mapDispatchToProps = (dispatch) => ({
-  getPlayerMatches: (playerId) => dispatch(getPlayerMatches(playerId)),
+  getPlayerMatches: (playerId, options = defaultOptions) => dispatch(getPlayerMatches(playerId, options)),
   getPlayerHeroes: (playerId) => dispatch(getPlayerHeroes(playerId)),
 });
 

--- a/src/components/Player/Pages/Overview/Overview.jsx
+++ b/src/components/Player/Pages/Overview/Overview.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {
-  connect
+  connect,
 } from 'react-redux';
 import {
   getPlayerMatches,
@@ -16,18 +16,18 @@ import {
 } from 'selectors';
 import {
   playerMatches,
-  playerHeroes
+  playerHeroes,
 } from 'reducers';
 import {
   createTable,
-  TableContainer
+  TableContainer,
 } from 'components/Table';
 import {
-  TableFilterForm
+  TableFilterForm,
 } from 'components/Form';
 import playerMatchesColumns from 'components/Player/Pages/Matches/playerMatchesColumns';
 import {
-  playerHeroesOverviewColumns
+  playerHeroesOverviewColumns,
 } from 'components/Player/Pages/Heroes/playerHeroesColumns';
 import styles from './Overview.css';
 
@@ -48,7 +48,7 @@ const getPlayerMatchesAndHeroes = (playerId, options) => dispatch => {
 };
 
 const Overview = ({
-  playerId
+  playerId,
 }) => (
   <div>
     <TableFilterForm submitAction={getPlayerMatchesAndHeroes} id={playerId} page="overview" />
@@ -85,7 +85,7 @@ class RequestLayer extends React.Component {
 }
 
 const defaultOptions = {
-  limit: [20]
+  limit: [20],
 };
 
 const mapDispatchToProps = (dispatch) => ({

--- a/src/components/Player/Pages/Peers/playerPeersColumns.jsx
+++ b/src/components/Player/Pages/Peers/playerPeersColumns.jsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router';
 import { transformations, getPercentWin } from 'utility';
 import { TablePercent } from 'components/Visualizations';
 import { AppBadge } from 'components/Player';
-import strings from 'lang/en';
+import strings from 'lang';
 
 const getPlayerPicture = (row, col, field) => (
   <div style={{ marginTop: 5 }}>

--- a/src/components/Player/Pages/Pros/playerProsColumns.jsx
+++ b/src/components/Player/Pages/Pros/playerProsColumns.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { transformations, getPercentWin } from 'utility';
 import { TableLink } from 'components/Table';
 import { TablePercent } from 'components/Visualizations';
-import strings from 'lang/en';
+import strings from 'lang';
 
 export default [{
   displayName: strings.th_avatar,

--- a/src/components/Player/Pages/Rankings/playerRankingsColumns.jsx
+++ b/src/components/Player/Pages/Rankings/playerRankingsColumns.jsx
@@ -1,5 +1,5 @@
 import { transformations, getPercentWin } from 'utility';
-import strings from 'lang/en';
+import strings from 'lang';
 
 export default [{
   displayName: strings.th_hero,

--- a/src/components/Player/Pages/Records/playerRecordsColumns.jsx
+++ b/src/components/Player/Pages/Records/playerRecordsColumns.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router';
 import { transformations, prettyPrint } from 'utility';
-import strings from 'lang/en';
+import strings from 'lang';
 
 export default [{
   displayName: strings.th_record,

--- a/src/lang/index.js
+++ b/src/lang/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable global-require */
 // TODO read/write language setting to local cookie
 const language = 'en';
 export default require(`./${language}.json`);

--- a/src/lang/index.js
+++ b/src/lang/index.js
@@ -1,0 +1,3 @@
+// TODO read/write language setting to local cookie
+const language = 'en';
+export default require(`./${language}.json`);


### PR DESCRIPTION
fixes #55 

* Send explicit match projections (need skill column)
* Load all matches on match page 
* Layout fix for counts tab
* Allow sorting on category column
* Update language import ('lang' instead of 'lang/en')

Reviewers:
@mike-robertson 
@albertcui 
@nicholashh 
@blukai 