### PR TITLE
📱 Overview match/hero tables no more squished together

### DIFF
--- a/src/components/Player/Pages/Overview/Overview.css
+++ b/src/components/Player/Pages/Overview/Overview.css
@@ -1,7 +1,22 @@
-.overviewContainer > div {
-  display: inline-block;
+@import "../../../palette.css";
+
+.overviewContainer {
+  display: flex;
+  flex-wrap: wrap;
 }
 
-.heroesContainer {
-  margin-left: 30px;
+.matchesTableContainer {
+  width: calc(70% - 30px);
+  margin-right: 30px;
+  @media only screen and (max-width: 1224px) {
+    width: 100%;
+    margin-right: 0;
+  }
+}
+
+.heroesTableContainer {
+  width: 30%;
+  @media only screen and (max-width: 1224px) {
+    width: 100%;
+  }
 }

--- a/src/components/Player/Pages/Overview/Overview.css
+++ b/src/components/Player/Pages/Overview/Overview.css
@@ -1,16 +1,4 @@
-@import "../../../palette.css";
-
-.overviewContainer {
-  display: flex;
-}
-
-.overviewMatches {
-  width: 75%;
-  display: inline-block;
-}
-
-.overviewHeroes {
-  width: 25%;
+.overviewContainer > div {
   display: inline-block;
 }
 

--- a/src/components/Player/Pages/Overview/Overview.jsx
+++ b/src/components/Player/Pages/Overview/Overview.jsx
@@ -1,7 +1,5 @@
 import React from 'react';
-import {
-  connect,
-} from 'react-redux';
+import { connect } from 'react-redux';
 import strings from 'lang';
 import {
   getPlayerMatches,
@@ -11,16 +9,10 @@ import {
   playerMatches,
   playerHeroes,
 } from 'reducers';
-import Table, {
-  TableContainer,
-} from 'components/Table';
-import {
-  TableFilterForm,
-} from 'components/Form';
+import Table, { TableContainer } from 'components/Table';
+import { TableFilterForm } from 'components/Form';
 import playerMatchesColumns from 'components/Player/Pages/Matches/playerMatchesColumns';
-import {
-  playerHeroesOverviewColumns,
-} from 'components/Player/Pages/Heroes/playerHeroesColumns';
+import { playerHeroesOverviewColumns } from 'components/Player/Pages/Heroes/playerHeroesColumns';
 import styles from './Overview.css';
 
 const getPlayerMatchesAndHeroes = (playerId, options) => (dispatch) => {
@@ -29,23 +21,34 @@ const getPlayerMatchesAndHeroes = (playerId, options) => (dispatch) => {
 };
 
 const MAX_OVERVIEW_ROWS = 20;
+const OVERVIEW_TABLES_BREAK_SIZE = 1224;
 
 const Overview = ({
   playerId,
   matchesData,
   heroesData,
+  width,
 }) => (
   <div>
     <TableFilterForm submitAction={getPlayerMatchesAndHeroes} id={playerId} page="overview" />
     <div className={styles.overviewContainer}>
-      <TableContainer title={strings.heading_matches} style={{ width: '70%' }}>
+      <TableContainer
+        title={strings.heading_matches}
+        style={{
+          width: width >= OVERVIEW_TABLES_BREAK_SIZE ? 'calc(70% - 30px)' : '100%',
+          marginRight: width >= OVERVIEW_TABLES_BREAK_SIZE ? 30 : 0,
+        }}
+      >
         <Table
           columns={playerMatchesColumns}
           data={matchesData}
           maxRows={MAX_OVERVIEW_ROWS}
         />
       </TableContainer>
-      <TableContainer title={strings.heading_heroes} style={{ marginLeft: 30, width: '30%' }}>
+      <TableContainer
+        title={strings.heading_heroes}
+        style={{ width: width >= OVERVIEW_TABLES_BREAK_SIZE ? '30%' : '100%' }}
+      >
         <Table
           columns={playerHeroesOverviewColumns}
           data={heroesData}
@@ -84,6 +87,7 @@ const defaultOptions = {
 const mapStateToProps = (state, { playerId }) => ({
   matchesData: playerMatches.getMatchList(state, playerId),
   heroesData: playerHeroes.getHeroList(state, playerId),
+  width: state.browser.width,
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/src/components/Player/Pages/Overview/Overview.jsx
+++ b/src/components/Player/Pages/Overview/Overview.jsx
@@ -21,23 +21,18 @@ const getPlayerMatchesAndHeroes = (playerId, options) => (dispatch) => {
 };
 
 const MAX_OVERVIEW_ROWS = 20;
-const OVERVIEW_TABLES_BREAK_SIZE = 1224;
 
 const Overview = ({
   playerId,
   matchesData,
   heroesData,
-  width,
 }) => (
   <div>
     <TableFilterForm submitAction={getPlayerMatchesAndHeroes} id={playerId} page="overview" />
     <div className={styles.overviewContainer}>
       <TableContainer
         title={strings.heading_matches}
-        style={{
-          width: width >= OVERVIEW_TABLES_BREAK_SIZE ? 'calc(70% - 30px)' : '100%',
-          marginRight: width >= OVERVIEW_TABLES_BREAK_SIZE ? 30 : 0,
-        }}
+        className={styles.matchesTableContainer}
       >
         <Table
           columns={playerMatchesColumns}
@@ -47,7 +42,7 @@ const Overview = ({
       </TableContainer>
       <TableContainer
         title={strings.heading_heroes}
-        style={{ width: width >= OVERVIEW_TABLES_BREAK_SIZE ? '30%' : '100%' }}
+        className={styles.heroesTableContainer}
       >
         <Table
           columns={playerHeroesOverviewColumns}
@@ -87,7 +82,6 @@ const defaultOptions = {
 const mapStateToProps = (state, { playerId }) => ({
   matchesData: playerMatches.getMatchList(state, playerId),
   heroesData: playerHeroes.getHeroList(state, playerId),
-  width: state.browser.width,
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/src/components/Table/TableContainer.jsx
+++ b/src/components/Table/TableContainer.jsx
@@ -2,8 +2,8 @@ import React from 'react';
 import Heading from 'components/Heading';
 import styles from './TableContainer.css';
 
-const TableContainer = ({ title, style, children }) => (
-  <div className={styles.container} style={{ ...style }}>
+const TableContainer = ({ title, style, className, children }) => (
+  <div className={`${styles.container} ${className}`} style={{ ...style }}>
     <div className={styles.heroesContainer}>
       <Heading title={title} />
       {children}


### PR DESCRIPTION
I have done a lot of shit in #253 💩 

issue #81 
> overview match/hero tables are squished together (they should stack if the viewport is too narrow? bootstrap handles this automatically)