### PR TITLE
distrib/rankings fixes

### DIFF
--- a/src/components/Distributions/Distributions.jsx
+++ b/src/components/Distributions/Distributions.jsx
@@ -48,17 +48,21 @@ const Distributions = ({
           <Heading title={strings[`distributions_${key}`]} />
           {(key === 'mmr') ?
             <div>
-              <div>{`${data
-              && data.mmr
-              && data.mmr.rows
-              && data.mmr.rows.map(row => row.count).reduce(sum)} ${strings.th_players}`}</div>
+              <div>
+                {`${data
+                && data.mmr
+                && data.mmr.rows
+                && data.mmr.rows.map(row => row.count).reduce(sum)} ${strings.th_players}`}
+              </div>
               <div id="mmr" />
             </div> :
               <div>
-                <div>{`${data
-              && data.country_mmr
-              && data.country_mmr.rows
-              && data.country_mmr.rows.map(row => row.count).reduce(sum)} ${strings.th_players}`}</div>
+                <div>
+                  {`${data
+                  && data.country_mmr
+                  && data.country_mmr.rows
+                  && data.country_mmr.rows.map(row => row.count).reduce(sum)} ${strings.th_players}`}
+                </div>
                 <Table data={data[key].rows} columns={countryMmrColumns} />
               </div>}
         </Tab>))

--- a/src/components/Distributions/Distributions.jsx
+++ b/src/components/Distributions/Distributions.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-// import CircularProgress from 'material-ui/CircularProgress';
 import {
   Tabs,
   Tab,
@@ -14,31 +13,58 @@ import {
 import strings from 'lang';
 import Table from 'components/Table';
 import Heading from 'components/Heading';
+import { sum } from 'utility';
+// import Spinner from 'components/Spinner';
 
 const countryMmrColumns = [{
-  displayName: 'Country',
+  displayName: '#',
+  field: '',
+  displayFn: (row, col, field, i) => i + 1,
+}, {
+  displayName: strings.th_country,
   field: 'common',
+  sortFn: true,
 }, {
-  displayName: 'Count',
+  displayName: strings.th_count,
   field: 'count',
+  sortFn: true,
 }, {
-  displayName: 'Average',
+  displayName: strings.th_average,
   field: 'avg',
+  sortFn: true,
 }];
 
 const Distributions = ({
   data,
+  // error,
+  // loading,
 }) => (
-  <Tabs>
-    {Object.keys(data).map(key => (
-      <Tab key={key} label={strings[`distributions_${key}`]}>
-        <Heading title={strings[`distributions_${key}`]} />
-        {(key === 'mmr') ?
-          <div id="mmr" /> :
-            <Table data={data[key].rows} columns={countryMmrColumns} />}
-      </Tab>))
-    }
-  </Tabs>
+  <div>
+    <div>{strings.distributions_warning_1}</div>
+    <div>{strings.distributions_warning_2}</div>
+    <Tabs>
+      {Object.keys(data).map(key => (
+        <Tab key={key} label={strings[`distributions_${key}`]}>
+          <Heading title={strings[`distributions_${key}`]} />
+          {(key === 'mmr') ?
+            <div>
+              <div>{`${data
+              && data.mmr
+              && data.mmr.rows
+              && data.mmr.rows.map(row => row.count).reduce(sum)} ${strings.th_players}`}</div>
+              <div id="mmr" />
+            </div> :
+              <div>
+                <div>{`${data
+              && data.country_mmr
+              && data.country_mmr.rows
+              && data.country_mmr.rows.map(row => row.count).reduce(sum)} ${strings.th_players}`}</div>
+                <Table data={data[key].rows} columns={countryMmrColumns} />
+              </div>}
+        </Tab>))
+      }
+    </Tabs>
+  </div>
 );
 
 class RequestLayer extends React.Component {
@@ -112,18 +138,7 @@ class RequestLayer extends React.Component {
   }
 }
 
-const mapStateToProps = (state) => {
-  const {
-    error,
-    loading,
-    data,
-  } = state.app.distributions;
-  return {
-    error,
-    loading,
-    data,
-  };
-};
+const mapStateToProps = state => state.app.distributions;
 
 const mapDispatchToProps = dispatch => ({
   dispatchDistributions: () => dispatch(getDistributions()),

--- a/src/components/Heroes/Benchmark.jsx
+++ b/src/components/Heroes/Benchmark.jsx
@@ -4,23 +4,14 @@ import React, {
 import {
   connect,
 } from 'react-redux';
-import CircularProgress from 'material-ui/CircularProgress';
 import {
   benchmark,
 } from 'reducers';
 import {
   getBenchmark,
 } from 'actions';
-
-import style from './Heroes.css';
-
+import Spinner from 'components/Spinner';
 import BenchmarkTable from './BenchmarkTable';
-
-const renderLoading = () => (
-  <div className={style.Loading}>
-    <CircularProgress color="#fff" />
-  </div>
-);
 
 const renderBenchmark = (hero, data) => (
   <div>
@@ -48,7 +39,7 @@ class Benchmark extends Component {
     return (
       <div>
         {isLoading || isError || result === null ?
-          renderLoading() : renderBenchmark(hero, result)}
+          <Spinner /> : renderBenchmark(hero, result)}
       </div>
     );
   }

--- a/src/components/Heroes/Ranking.jsx
+++ b/src/components/Heroes/Ranking.jsx
@@ -4,23 +4,15 @@ import React, {
 import {
   connect,
 } from 'react-redux';
-import CircularProgress from 'material-ui/CircularProgress';
-
 import {
   ranking,
 } from 'reducers';
 import {
   getRanking,
 } from 'actions';
-
-import style from './Heroes.css';
+import Spinner from 'components/Spinner';
+// import style from './Heroes.css';
 import RankingTable from './RankingTable';
-
-const renderLoading = () => (
-  <div className={style.Loading}>
-    <CircularProgress color="#fff" />
-  </div>
-);
 
 const renderRanking = (hero, rankings) => (
   <div>
@@ -47,7 +39,7 @@ class Ranking extends Component {
     return (
       <div>
         {isLoading || isError || rankings === null ?
-          renderLoading() : renderRanking(hero, rankings)}
+          <Spinner /> : renderRanking(hero, rankings)}
       </div>
     );
   }

--- a/src/components/Heroes/RankingTable.jsx
+++ b/src/components/Heroes/RankingTable.jsx
@@ -1,55 +1,34 @@
 import React from 'react';
-import {
-  Table,
-  TableBody,
-  TableHeader,
-  TableHeaderColumn,
-  TableRow,
-  TableRowColumn,
-} from 'material-ui/Table';
+import Table from 'components/Table';
 import Avatar from 'material-ui/Avatar';
-import { Link } from 'react-router';
-
+import {
+  Link,
+} from 'react-router';
+import strings from 'lang';
 import style from './Heroes.css';
 
-export default ({ rankings }) => {
-  if (!rankings || rankings.length === 0) {
-    return <div />;
-  }
-
-  return (
-    <Table className={style.RankingTable}>
-      <TableHeader displaySelectAll={false} adjustForCheckbox={false}>
-        <TableRow>
-          {/* TODO localize strings*/}
-          <TableHeaderColumn className={style.RankingColNo}>#</TableHeaderColumn>
-          <TableHeaderColumn>Name</TableHeaderColumn>
-          <TableHeaderColumn>Score</TableHeaderColumn>
-        </TableRow>
-      </TableHeader>
-      <TableBody displayRowCheckbox={false}>
-        {rankings.map((ranking, i) => (
-          <TableRow selectable={false} key={ranking.account_id}>
-            <TableRowColumn className={style.RankingColNo} style={{ textAlign: 'center' }}>{i + 1}</TableRowColumn>
-            <TableRowColumn>
-              <div className={style.RankingName}>
-                <Avatar
-                  src={ranking.avatarfull}
-                  size={30}
-                  className={style.RankingAvatar}
-                />
-                <h3 className={style.RankingPersonaName}>
-                  <Link to={`/players/${ranking.account_id}`}>
-                    {ranking.personaname}
-                  </Link>
-                </h3>
-                {ranking.solo_competitive_rank ? <span>{ranking.solo_competitive_rank} MMR</span> : ''}
-              </div>
-            </TableRowColumn>
-            <TableRowColumn>{parseFloat(ranking.score).toFixed()}</TableRowColumn>
-          </TableRow>
-        ))}
-      </TableBody>
-    </Table>
-  );
-};
+const rankingColumns = [{
+  displayName: '#',
+  displayFn: (row, col, field, index) => index + 1,
+}, {
+  displayName: strings.th_name,
+  displayFn: row => (<div className={style.RankingName}>
+    <Avatar
+      src={row.avatarfull}
+      size={30}
+      className={style.RankingAvatar}
+    />
+    <h3 className={style.RankingPersonaName}>
+      <Link to={`/players/${row.account_id}`}>
+        {row.personaname}
+      </Link>
+    </h3>
+    {row.solo_competitive_rank ? <span>{row.solo_competitive_rank} MMR</span> : ''}
+  </div>),
+}, {
+  displayName: strings.th_score,
+  displayFn: row => parseFloat(row.score).toFixed(),
+}];
+export default ({
+  rankings,
+}) => (<Table data={rankings} columns={rankingColumns} />);

--- a/src/components/Match/matchColumns.jsx
+++ b/src/components/Match/matchColumns.jsx
@@ -48,9 +48,8 @@ export const heroTdColumn = {
 
 export const overviewColumns = match => [{
   field: '',
-  displayFn: (row) => {
+  displayFn: (row, col, field, i) => {
     if (match.parties) {
-      const i = match.players.findIndex(player => player.player_slot === row.player_slot);
       const partyPrev = match.parties[(match.players[i - 1] || {}).player_slot] === match.parties[match.players[i].player_slot];
       const partyNext = match.parties[(match.players[i + 1] || {}).player_slot] === match.parties[match.players[i].player_slot];
       const parentStyle = {

--- a/src/components/Table/Table.jsx
+++ b/src/components/Table/Table.jsx
@@ -45,7 +45,7 @@ const getTable = (data, columns, sortState, sortField, sortClick) => (
               };
               return (
                 <MaterialTableRowColumn key={colIndex} style={MaterialTableRowColumnStyle}>
-                  {row && column.displayFn && column.displayFn(row, column, row[column.field])}
+                  {row && column.displayFn && column.displayFn(row, column, row[column.field], index)}
                   {row && !column.displayFn && row[column.field]}
                 </MaterialTableRowColumn>
               );

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -16,6 +16,8 @@
 
   "distributions_mmr": "Solo MMR",
   "distributions_country_mmr": "Solo MMR By Country",
+  "distributions_warning_1": "Warning! This data set is limited to players displaying MMR on profile and sharing public match data.",
+  "distributions_warning_2": "Players do not have to sign in, but due to the opt-in nature of the data collected, averages are likely higher than expected.",
 
   "error": "Error",
   "error_message": "Whoops! Something went wrong.",
@@ -280,6 +282,11 @@
   "th_DOTA_UNIT_ORDER_HOLD_POSITION": "HLD",
   "th_DOTA_UNIT_ORDER_GLYPH": "GLYPH",
   "th_DOTA_UNIT_ORDER_RADAR": "SCN",
+  "th_country": "Country",
+  "th_count": "Count",
+  "th_average": "Average",
+  "th_name": "Name",
+  "th_score": "Score",
 
   "time_just_now": "just now",
   "time_second": "second",


### PR DESCRIPTION
fixes #257 

* Use standard Table element
* Use standard spinner element
* Externalize some strings

Could use some more styling on the distributions warning/number of players display.

Reviewers:
@bguzryanto 
@nicholashh 
@albertcui 