### PR TITLE
fixes to table scroll. Fixes to counts page in pure css.

### DIFF
--- a/src/components/Player/Pages/Counts/Counts.css
+++ b/src/components/Player/Pages/Counts/Counts.css
@@ -1,10 +1,8 @@
 .countTable {
-  width: 50%;
+  flex-grow: 1;
+  overflow-x:auto;
   box-sizing: border-box;
   padding: 15px;
-  @media (max-width: 960px) {
-    width: 100%;
-  }
 }
 
 .countsContainer {

--- a/src/components/Table/Table.css
+++ b/src/components/Table/Table.css
@@ -3,19 +3,12 @@
 .container {
   min-width: 100%;
   clear: both;
-  @media only screen and (max-width: 960px) {
-    overflow-x: scroll;
-  }
 }
 
-.innerContainer {
-  @media only screen and (max-width: 960px) {
-    min-width: 1325px;
-  }
-}
-
+/*Override material-ui style*/
 .innerContainer > div > div {
-  overflow: hidden !important;
+  overflow-y: hidden !important;
+  overflow-x: auto !important;
 }
 
 .header {


### PR DESCRIPTION
iphone 5 (320) Table is scrollable at this size:
![](http://i.imgur.com/oOFzka1.png)

second 'breakpoint':
![](http://i.imgur.com/WXlnBJ9.png)

full screensize:
![](http://i.imgur.com/COp0cFY.png)