### PR TITLE
remove request from navbar

### DIFF
--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -16,9 +16,6 @@ import SearchForm from '../Search/SearchForm';
 import AppLogo from '../App/AppLogo';
 
 const navbarPages = [{
-  name: strings.header_request,
-  path: '/request',
-}, {
   name: strings.header_distributions,
   path: '/distributions',
 }, {


### PR DESCRIPTION
The main purpose of requests are:
* Allow new users to see what replay parsing offers without needing to sign in (onboarding)
* Bump a particular match to the front of the queue
* Re-parsing matches when new parser code is deployed (not that common anymore)
* Parse a match that got skipped due to no active users/on-demand parsing of someone's random match

As such, I don't think it deserves a navbar position.  It should remain on the home page for new users, and linked on individual match pages (for existing users trying to parse a particular match).