### PR TITLE
fix issue #312

### DIFF
--- a/src/components/Match/CrossTable.css
+++ b/src/components/Match/CrossTable.css
@@ -1,0 +1,7 @@
+/*Override material-ui style*/
+.innerContainer {
+  & > div > div:nth-child(2) {
+    overflow-y: hidden !important;
+    overflow-x: auto !important;
+  }
+}

--- a/src/components/Match/CrossTable.jsx
+++ b/src/components/Match/CrossTable.jsx
@@ -8,34 +8,40 @@ import {
 import heroes from 'dotaconstants/json/heroes.json';
 import { abbreviateNumber } from 'utility';
 import { heroTd } from './matchColumns';
+import styles from './CrossTable.css';
 
 const CrossTable = ({
   match,
   field1,
   field2,
 }) => (
-  <Table selectable={false}>
-    <TableBody displayRowCheckbox={false}>
-      <TableRow>
-        <TableRowColumn>Hero</TableRowColumn>
-        {match.players.slice(0, match.players.length / 2).map((player, i) => (
-          <TableRowColumn key={player.hero_id}>
-            {heroTd(player, 'hero_id', player.hero_id, i, true)}
-          </TableRowColumn>)
-        )}
-      </TableRow>
-      {match.players.slice(match.players.length / 2, match.players.length).map((player, i) => (<TableRow key={player.hero_id}>
-        <TableRowColumn>{heroTd(player, 'hero_id', player.hero_id, i, true)}</TableRowColumn>
-        {match.players.slice(0, match.players.length / 2).map((p2) => {
-          const hero2 = heroes[p2.hero_id] || {};
-          const pfield1 = player[field1] || {};
-          const pfield2 = player[field2] || {};
-          return (<TableRowColumn key={p2.hero_id}>
-            {`${abbreviateNumber(pfield1[hero2.name] || 0)}/${abbreviateNumber(pfield2[hero2.name] || 0)}`}
-          </TableRowColumn>);
-        })}
-      </TableRow>))}
-    </TableBody>
-  </Table>);
+  <div className={styles.innerContainer}>
+    <Table selectable={false}>
+      <TableBody displayRowCheckbox={false}>
+        <TableRow>
+          <TableRowColumn>Hero</TableRowColumn>
+          {match.players.slice(0, match.players.length / 2).map((player, i) => (
+            <TableRowColumn key={player.hero_id}>
+              {heroTd(player, 'hero_id', player.hero_id, i, true)}
+            </TableRowColumn>)
+          )}
+        </TableRow>
+        {match.players.slice(match.players.length / 2, match.players.length).map((player, i) => (<TableRow key={player.hero_id}>
+          <TableRowColumn>{heroTd(player, 'hero_id', player.hero_id, i, true)}</TableRowColumn>
+          {match.players.slice(0, match.players.length / 2).map((p2) => {
+            const hero2 = heroes[p2.hero_id] || {};
+            const pfield1 = player[field1] || {};
+            const pfield2 = player[field2] || {};
+            return (
+              <TableRowColumn key={p2.hero_id}>
+                {`${abbreviateNumber(pfield1[hero2.name] || 0)}/${abbreviateNumber(pfield2[hero2.name] || 0)}`}
+              </TableRowColumn>
+            );
+          })}
+        </TableRow>))}
+      </TableBody>
+    </Table>
+  </div>
+);
 
 export default CrossTable;

--- a/src/components/Match/matchPages.css
+++ b/src/components/Match/matchPages.css
@@ -1,0 +1,12 @@
+.container {
+  display: flex;
+  flex-wrap: wrap;
+  overflow: hidden;
+  margin: 0 -10px;
+}
+
+.tableContainer {
+  max-width: 100%;
+  flex-grow: 1;
+  margin: 0 10px;
+}

--- a/src/components/Match/matchPages.jsx
+++ b/src/components/Match/matchPages.jsx
@@ -10,7 +10,7 @@ import {
   Tab,
 } from 'material-ui/Tabs';
 import Heading from 'components/Heading';
-import Table from 'components/Table';
+import Table, { TableContainer } from 'components/Table';
 import { Row, Col } from 'react-flexbox-grid';
 import { IconRadiant, IconDire } from 'components/Icons';
 import FlatButton from 'material-ui/FlatButton';
@@ -44,6 +44,7 @@ import {
   inflictorsColumns,
 } from './matchColumns';
 import styles from './Match.css';
+import pageStyles from './matchPages.css';
 
 const filterMatchPlayers = (players, team = '') =>
   players.filter(player =>
@@ -54,8 +55,9 @@ const TeamTable = ({
   match,
   columns,
   heading = '',
+  className,
 }) => (
-  <div>
+  <div className={className}>
     <Heading
       title={`${strings.general_radiant} ${heading}`}
       icon={<IconRadiant className={styles.iconRadiant} />}
@@ -112,21 +114,21 @@ const matchPages = [{
                   containerElement={<Link to={`/request#${match.match_id}`}>r</Link>}
                 />
                 {match.replay_url &&
-                  <FlatButton
-                    label={strings.match_button_replay}
-                    icon={<FileFileDownload />}
-                    href={match.replay_url}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  />}
+                <FlatButton
+                  label={strings.match_button_replay}
+                  icon={<FileFileDownload />}
+                  href={match.replay_url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                />}
                 {match.replay_url &&
-                  <FlatButton
-                    label={strings.match_button_video}
-                    icon={<img src="/assets/images/jist-24x24.png" role="presentation" />}
-                    href={`//www.jist.tv/create.php?dota2-match-url=${match.replay_url}`}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  />}
+                <FlatButton
+                  label={strings.match_button_video}
+                  icon={<img src="/assets/images/jist-24x24.png" role="presentation" />}
+                  href={`//www.jist.tv/create.php?dota2-match-url=${match.replay_url}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                />}
                 <FlatButton
                   label={strings.app_dotacoach}
                   icon={<img src="/assets/images/dotacoach-32x24.png" role="presentation" />}
@@ -138,12 +140,12 @@ const matchPages = [{
             </Col>
             <Col lg={6} xs={12} className={styles.matchNumbers}>
               {match.first_blood_time !== undefined &&
+              <div>
                 <div>
-                  <div>
-                    <span>{strings.match_first_blood} </span>
-                    {formatSeconds(match.first_blood_time)}
-                  </div>
-                </div>}
+                  <span>{strings.match_first_blood} </span>
+                  {formatSeconds(match.first_blood_time)}
+                </div>
+              </div>}
               {firstNumbers()}
             </Col>
           </Row>
@@ -175,19 +177,15 @@ const matchPages = [{
   ]),
 }, {
   name: strings.tab_combat,
-  content: match => (<Row>
-    <Col md={6}>
-      <Heading title={strings.heading_kills} />
+  content: match => (<div className={pageStyles.container}>
+    <TableContainer title={strings.heading_kills} className={pageStyles.tableContainer}>
       <CrossTable match={match} field1="killed" field2="killed_by" />
-    </Col>
-    <Col md={6}>
-      <Heading title={strings.heading_damage} />
+    </TableContainer>
+    <TableContainer title={strings.heading_damage} className={pageStyles.tableContainer}>
       <CrossTable match={match} field1="damage" field2="damage_taken" />
-    </Col>
-    <Col md={12}>
-      <TeamTable match={match} columns={inflictorsColumns} heading={strings.heading_damage} />
-    </Col>
-  </Row>),
+    </TableContainer>
+    <TeamTable className={pageStyles.tableContainer} match={match} columns={inflictorsColumns} heading={strings.heading_damage} />
+  </div>),
 }, {
   name: strings.tab_farm,
   content: match => (<div>

--- a/src/components/Match/matchPages.jsx
+++ b/src/components/Match/matchPages.jsx
@@ -112,21 +112,21 @@ const matchPages = [{
                   containerElement={<Link to={`/request#${match.match_id}`}>r</Link>}
                 />
                 {match.replay_url &&
-                <FlatButton
-                  label={strings.match_button_replay}
-                  icon={<FileFileDownload />}
-                  href={match.replay_url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                />}
+                  <FlatButton
+                    label={strings.match_button_replay}
+                    icon={<FileFileDownload />}
+                    href={match.replay_url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  />}
                 {match.replay_url &&
-                <FlatButton
-                  label={strings.match_button_video}
-                  icon={<img src="/assets/images/jist-24x24.png" role="presentation" />}
-                  href={`//www.jist.tv/create.php?dota2-match-url=${match.replay_url}`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                />}
+                  <FlatButton
+                    label={strings.match_button_video}
+                    icon={<img src="/assets/images/jist-24x24.png" role="presentation" />}
+                    href={`//www.jist.tv/create.php?dota2-match-url=${match.replay_url}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  />}
                 <FlatButton
                   label={strings.app_dotacoach}
                   icon={<img src="/assets/images/dotacoach-32x24.png" role="presentation" />}
@@ -138,12 +138,12 @@ const matchPages = [{
             </Col>
             <Col lg={6} xs={12} className={styles.matchNumbers}>
               {match.first_blood_time !== undefined &&
-              <div>
                 <div>
-                  <span>{strings.match_first_blood} </span>
-                  {formatSeconds(match.first_blood_time)}
-                </div>
-              </div>}
+                  <div>
+                    <span>{strings.match_first_blood} </span>
+                    {formatSeconds(match.first_blood_time)}
+                  </div>
+                </div>}
               {firstNumbers()}
             </Col>
           </Row>
@@ -169,14 +169,10 @@ const matchPages = [{
   </div>),
 }, {
   name: strings.tab_performances,
-  content: match => (<Row>
-    <Col md={12}>
-      <TeamTable match={match} columns={performanceColumns} heading={strings.heading_performances} />
-    </Col>
-    <Col md={12}>
-      <TeamTable match={match} columns={supportColumns} heading={strings.heading_support} />
-    </Col>
-  </Row>),
+  content: match => ([
+    <TeamTable match={match} columns={performanceColumns} heading={strings.heading_performances} />,
+    (<TeamTable match={match} columns={supportColumns} heading={strings.heading_support} />),
+  ]),
 }, {
   name: strings.tab_combat,
   content: match => (<Row>

--- a/src/components/Table/TableContainer.jsx
+++ b/src/components/Table/TableContainer.jsx
@@ -3,7 +3,7 @@ import Heading from 'components/Heading';
 import styles from './TableContainer.css';
 
 const TableContainer = ({ title, style, className, children }) => (
-  <div className={`${styles.container} ${className}`} style={{ ...style }}>
+  <div className={className} style={{ ...style }}>
     <div className={styles.heroesContainer}>
       <Heading title={title} />
       {children}


### PR DESCRIPTION
Some tables in matches don't scroll in mobile when they should. It seems to be because the Row and Column components interfere with the overflow of the tables. Some of these are completely unneeded (for example, when the row column is only max size). Others will require overriding of styles or something to make work.
