### PR TITLE
Fix spinner's error

### DIFF
--- a/src/components/Spinner/Spinner.jsx
+++ b/src/components/Spinner/Spinner.jsx
@@ -3,6 +3,6 @@ import CircularProgress from 'material-ui/CircularProgress';
 
 export default ({ size = 59.5, color = '#00BCD4' }) => (
   <div style={{ textAlign: 'center' }}>
-    <CircularProgress size={size} color={color} />
+    <CircularProgress size={Math.max(size, 4)} color={color} />
   </div>
 );


### PR DESCRIPTION
> Error: <circle> attribute r: A negative value is not valid. ("-1.5")

https://github.com/callemall/material-ui/issues/5338#issuecomment-252008520 4 is OK
I could find wrong values but prefer to avoid this by `Math.max` so if someone use spinner in future with wrong size this will make no warn.