### PR TITLE
A few misc changes

### DIFF
--- a/src/components/Player/Pages/Records/Records.jsx
+++ b/src/components/Player/Pages/Records/Records.jsx
@@ -14,7 +14,7 @@ const Records = ({ data, error, loading }) => (
   <div>
     <TableFilterForm />
     <Container title={strings.heading_records} error={error} loading={loading}>
-      <Table paginated columns={playerRecordsColumns} data={data} />
+      <Table columns={playerRecordsColumns} data={data} />
     </Container>
   </div>
 );

--- a/src/components/Visualizations/Table/HeroImage.css
+++ b/src/components/Visualizations/Table/HeroImage.css
@@ -32,14 +32,14 @@
   left: -24px;
   width: 2px;
   height: 29px;
-  background-color: var(--colorSuccess);
   align-self: center;
+  background-color: var(--primaryLinkColor);
 
   /* Material-ui icon */
   & svg {
     position: relative !important;
     left: -10px !important;
-    fill: var(--colorSuccess) !important;
+    fill: var(--primaryLinkColor) !important;
   }
 }
 .unparsed {


### PR DESCRIPTION
1. Records page is no longer paginated. (We don't need it to be)
2. Use blue color for parsed successful status. So, that it's not confused with winning at first glance

    > Even though I know it's a parse status, I kept thinking that it was
some other indication (like winning) since it's green in color

3. In a match page, if the dire wins, move the dire victory header to the right and match meta info to the left. (Like how it is in dota2 game)