### PR TITLE
Reduced map image opacity for heat maps

### DIFF
--- a/src/components/Heatmap/Heatmap.jsx
+++ b/src/components/Heatmap/Heatmap.jsx
@@ -60,7 +60,14 @@ class Heatmap extends Component {
         }}
         id={this.id}
       >
-        <img width={this.props.width} src="/assets/images/map.png" role="presentation" />
+        <img
+          style={{
+            width: this.props.width,
+            opacity: 0.7,
+          }}
+          src="/assets/images/map.png"
+          role="presentation"
+        />
       </div>);
   }
 }


### PR DESCRIPTION
Heat maps are difficult to see at times, particularly on the Radiant side, due to the high green contrast of the map. _Slightly_ darkened the map (reduced opacity) to cause the heat map information to pop more easily.

| Original | Updated |
| -------- | ------- |
| ![screen shot 2016-11-08 at 11 19 43 am](https://cloud.githubusercontent.com/assets/4400/20082425/9e30e09a-a5a5-11e6-972c-89a23f9c7549.png) | ![screen shot 2016-11-08 at 11 19 48 am](https://cloud.githubusercontent.com/assets/4400/20082435/b7e5c8ca-a5a5-11e6-9f81-f2f49ac3bb10.png) |
