### PR TITLE
Adds peerDependency on fbjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,5 +77,8 @@
   "moduleRoots": [
     "./src",
     "./node_modules"
-  ]
+  ],
+  "peerDependencies": {
+    "fbjs": "^0.8.5"
+  }
 }


### PR DESCRIPTION
From a clean state, there is a missing dependency on fbjs. As this is not a strict dependency, adding to `peerDependencies` as per https://nodejs.org/en/blog/npm/peer-dependencies/

Without this PR, a clean `npm install && npm run` fails.