### PR TITLE
Fix tab bar growing larger than 1440px + FFox tab bar scrolling issues

### DIFF
--- a/src/components/TabBar/TabBar.css
+++ b/src/components/TabBar/TabBar.css
@@ -47,6 +47,5 @@
     overflow-x: auto;
     overflow-y: hidden;
     -ms-overflow-style: none;
-    overflow: -moz-scrollbars-none;
   }
 }

--- a/src/components/TabBar/TabBar.css
+++ b/src/components/TabBar/TabBar.css
@@ -17,7 +17,7 @@
     font-weight: var(--fontWeightLight);
     font-size: 15px;
     color: var(--primaryTextColor);
-    padding: 10px 14px 16px;
+    padding: 10px 12px 16px;
     border-bottom: 2px solid transparent;
     flex-grow: 1;
 


### PR DESCRIPTION
Fixes being unable to scroll to see other tabs on certain screen sizes, as well as being unable to scroll entirely on FFox
Temporarily papers over the issue that the tab bar doesn't wrap #420