### PR TITLE
Display permanent_buffs

### DIFF
--- a/src/components/Match/matchColumns.jsx
+++ b/src/components/Match/matchColumns.jsx
@@ -17,6 +17,7 @@ import {
   transformations,
   percentile,
   sum,
+  unpackPositionData,
 } from 'utility';
 import Heatmap from 'components/Heatmap';
 import {
@@ -313,9 +314,9 @@ export const performanceColumns = [
   }, {
     displayName: strings.th_map,
     tooltip: strings.tooltip_map,
-    field: 'posData',
+    field: 'lane_pos',
     displayFn: (row, col, field) => (field ?
-      <Heatmap width={80} points={field.lane_pos} /> :
+      <Heatmap width={80} points={unpackPositionData(field)} /> :
       <div />),
   }, {
     displayName: strings.th_lane_efficiency,

--- a/src/components/Match/matchColumns.jsx
+++ b/src/components/Match/matchColumns.jsx
@@ -9,6 +9,7 @@ import abilityIds from 'dotaconstants/json/ability_ids.json';
 import abilityKeys from 'dotaconstants/json/ability_keys.json';
 import heroNames from 'dotaconstants/json/hero_names.json';
 import laneRole from 'dotaconstants/json/lane_role.json';
+import buffs from 'dotaconstants/json/permanent_buffs.json';
 import strings from 'lang';
 import {
   formatSeconds,
@@ -16,7 +17,6 @@ import {
   transformations,
   percentile,
   sum,
-  unpackPositionData,
 } from 'utility';
 import Heatmap from 'components/Heatmap';
 import {
@@ -193,6 +193,15 @@ export const overviewColumns = match => [{
     );
   },
 }, {
+  displayName: 'Buffs',
+  field: 'permanent_buffs',
+  displayFn: row => ( // buff.permanent_buff, buff.stack_count
+    row.permanent_buffs && row.permanent_buffs.length > 0
+      ? row.permanent_buffs.map(buff => inflictorWithValue(buffs[buff.permanent_buff], buff.stack_count, 'buff'))
+      : ' - '
+  ),
+  parsed: true,
+}, {
   displayName: (
     <div style={{ marginLeft: 10 }}>
       {strings.th_ability_builds}
@@ -304,9 +313,9 @@ export const performanceColumns = [
   }, {
     displayName: strings.th_map,
     tooltip: strings.tooltip_map,
-    field: 'lane_pos',
+    field: 'posData',
     displayFn: (row, col, field) => (field ?
-      <Heatmap width={80} points={unpackPositionData(field)} /> :
+      <Heatmap width={80} points={field.lane_pos} /> :
       <div />),
   }, {
     displayName: strings.th_lane_efficiency,

--- a/src/components/Match/matchColumns.jsx
+++ b/src/components/Match/matchColumns.jsx
@@ -194,7 +194,20 @@ export const overviewColumns = (match) => {
         </div>
       );
     },
-  }, {
+  }]
+  .concat(
+    match.players.map(player => player.permanent_buffs && player.permanent_buffs.length).reduce(sum, 0) > 0 &&
+      {
+        displayName: strings.th_permanent_buffs,
+        field: 'permanent_buffs',
+        displayFn: row => (
+          row.permanent_buffs && row.permanent_buffs.length > 0
+            ? row.permanent_buffs.map(buff => inflictorWithValue(buffs[buff.permanent_buff], buff.stack_count, 'buff'))
+            : '-'
+        ),
+      },
+  )
+  .concat({
     displayName: (
       <div style={{ marginLeft: 10 }}>
         {strings.th_ability_builds}
@@ -221,19 +234,7 @@ export const overviewColumns = (match) => {
         </ReactTooltip>
       </div>
     ),
-  }];
-
-  if (match.players.map(player => player.permanent_buffs && player.permanent_buffs.length).reduce(sum) > 0) {
-    cols.splice(cols.length - 1, 0, {
-      displayName: strings.th_permanent_buffs,
-      field: 'permanent_buffs',
-      displayFn: row => (
-        row.permanent_buffs && row.permanent_buffs.length > 0
-          ? row.permanent_buffs.map(buff => inflictorWithValue(buffs[buff.permanent_buff], buff.stack_count, 'buff'))
-          : '-'
-      ),
-    });
-  }
+  });
 
   return cols;
 };

--- a/src/components/Match/matchColumns.jsx
+++ b/src/components/Match/matchColumns.jsx
@@ -79,157 +79,164 @@ const parties = (row, match) => {
   return null;
 };
 
-export const overviewColumns = match => [{
-  displayName: 'Player',
-  field: 'player_slot',
-  displayFn: (row, col, field, i) => heroTd(row, col, field, i, false, parties(row, match)),
-  sortFn: true,
-}, {
-  displayName: strings.th_level,
-  tooltip: strings.tooltip_level,
-  field: 'level',
-  sortFn: true,
-  maxFn: true,
-}, {
-  displayName: strings.th_kills,
-  tooltip: strings.tooltip_kills,
-  field: 'kills',
-  sortFn: true,
-  displayFn: transformations.kda,
-}, {
-  displayName: strings.th_deaths,
-  tooltip: strings.tooltip_deaths,
-  field: 'deaths',
-  sortFn: true,
-}, {
-  displayName: strings.th_assists,
-  tooltip: strings.tooltip_assists,
-  field: 'assists',
-  sortFn: true,
-}, {
-  displayName: strings.th_gold_per_min,
-  tooltip: strings.tooltip_gold_per_min,
-  field: 'gold_per_min',
-  sortFn: true,
-  color: styles.golden,
-}, {
-  displayName: strings.th_xp_per_min,
-  tooltip: strings.tooltip_xp_per_min,
-  field: 'xp_per_min',
-  sortFn: true,
-}, {
-  displayName: strings.th_last_hits,
-  tooltip: strings.tooltip_last_hits,
-  field: 'last_hits',
-  sortFn: true,
-}, {
-  displayName: strings.th_denies,
-  tooltip: strings.tooltip_denies,
-  field: 'denies',
-  sortFn: true,
-}, {
-  displayName: strings.th_hero_damage,
-  tooltip: strings.tooltip_hero_damage,
-  field: 'hero_damage',
-  displayFn: row => abbreviateNumber(row.hero_damage),
-  sortFn: true,
-}, {
-  displayName: strings.th_hero_healing,
-  tooltip: strings.tooltip_hero_healing,
-  field: 'hero_healing',
-  displayFn: row => abbreviateNumber(row.hero_healing),
-  sortFn: true,
-}, {
-  displayName: strings.th_tower_damage,
-  tooltip: strings.tooltip_tower_damage,
-  field: 'tower_damage',
-  displayFn: row => abbreviateNumber(row.tower_damage),
-  sortFn: true,
-}, {
-  displayName: (
-    <span className={styles.thGold}>
-      <img src={`${API_HOST}/apps/dota2/images/tooltips/gold.png`} role="presentation" />
-      {strings.th_gold}
-    </span>
-  ),
-  tooltip: strings.tooltip_gold,
-  field: 'gold_per_min',
-  displayFn: row => abbreviateNumber((row.gold_per_min * row.duration) / 60),
-  sortFn: true,
-  color: styles.golden,
-}, {
-  displayName: strings.th_items,
-  tooltip: strings.tooltip_items,
-  field: 'items',
-  displayFn: (row) => {
-    const itemArray = [];
-    const additionalItemArray = [];
-    for (let i = 0; i < 6; i += 1) {
-      const itemKey = itemIds[row[`item_${i}`]];
-      const firstPurchase = row.first_purchase_time && row.first_purchase_time[itemKey];
+export const overviewColumns = (match) => {
+  const cols = [{
+    displayName: 'Player',
+    field: 'player_slot',
+    displayFn: (row, col, field, i) => heroTd(row, col, field, i, false, parties(row, match)),
+    sortFn: true,
+  }, {
+    displayName: strings.th_level,
+    tooltip: strings.tooltip_level,
+    field: 'level',
+    sortFn: true,
+    maxFn: true,
+  }, {
+    displayName: strings.th_kills,
+    tooltip: strings.tooltip_kills,
+    field: 'kills',
+    sortFn: true,
+    displayFn: transformations.kda,
+  }, {
+    displayName: strings.th_deaths,
+    tooltip: strings.tooltip_deaths,
+    field: 'deaths',
+    sortFn: true,
+  }, {
+    displayName: strings.th_assists,
+    tooltip: strings.tooltip_assists,
+    field: 'assists',
+    sortFn: true,
+  }, {
+    displayName: strings.th_gold_per_min,
+    tooltip: strings.tooltip_gold_per_min,
+    field: 'gold_per_min',
+    sortFn: true,
+    color: styles.golden,
+  }, {
+    displayName: strings.th_xp_per_min,
+    tooltip: strings.tooltip_xp_per_min,
+    field: 'xp_per_min',
+    sortFn: true,
+  }, {
+    displayName: strings.th_last_hits,
+    tooltip: strings.tooltip_last_hits,
+    field: 'last_hits',
+    sortFn: true,
+  }, {
+    displayName: strings.th_denies,
+    tooltip: strings.tooltip_denies,
+    field: 'denies',
+    sortFn: true,
+  }, {
+    displayName: strings.th_hero_damage,
+    tooltip: strings.tooltip_hero_damage,
+    field: 'hero_damage',
+    displayFn: row => abbreviateNumber(row.hero_damage),
+    sortFn: true,
+  }, {
+    displayName: strings.th_hero_healing,
+    tooltip: strings.tooltip_hero_healing,
+    field: 'hero_healing',
+    displayFn: row => abbreviateNumber(row.hero_healing),
+    sortFn: true,
+  }, {
+    displayName: strings.th_tower_damage,
+    tooltip: strings.tooltip_tower_damage,
+    field: 'tower_damage',
+    displayFn: row => abbreviateNumber(row.tower_damage),
+    sortFn: true,
+  }, {
+    displayName: (
+      <span className={styles.thGold}>
+        <img src={`${API_HOST}/apps/dota2/images/tooltips/gold.png`} role="presentation" />
+        {strings.th_gold}
+      </span>
+    ),
+    tooltip: strings.tooltip_gold,
+    field: 'gold_per_min',
+    displayFn: row => abbreviateNumber((row.gold_per_min * row.duration) / 60),
+    sortFn: true,
+    color: styles.golden,
+  }, {
+    displayName: strings.th_items,
+    tooltip: strings.tooltip_items,
+    field: 'items',
+    displayFn: (row) => {
+      const itemArray = [];
+      const additionalItemArray = [];
+      for (let i = 0; i < 6; i += 1) {
+        const itemKey = itemIds[row[`item_${i}`]];
+        const firstPurchase = row.first_purchase_time && row.first_purchase_time[itemKey];
 
-      if (items[itemKey]) {
-        itemArray.push(
-          inflictorWithValue(itemKey, formatSeconds(firstPurchase)),
-        );
-      }
-
-      // Use hero_id because Meepo showing up as an additional unit in some matches http://dev.dota2.com/showthread.php?t=132401
-      if (row.hero_id === 80 && row.additional_units) {
-        const additionalItemKey = itemIds[row.additional_units[0][`item_${i}`]];
-        const additionalFirstPurchase = row.first_purchase_time && row.first_purchase_time[additionalItemKey];
-
-        if (items[additionalItemKey]) {
-          additionalItemArray.push(
-            inflictorWithValue(additionalItemKey, formatSeconds(additionalFirstPurchase)),
+        if (items[itemKey]) {
+          itemArray.push(
+            inflictorWithValue(itemKey, formatSeconds(firstPurchase)),
           );
         }
+
+        // Use hero_id because Meepo showing up as an additional unit in some matches http://dev.dota2.com/showthread.php?t=132401
+        if (row.hero_id === 80 && row.additional_units) {
+          const additionalItemKey = itemIds[row.additional_units[0][`item_${i}`]];
+          const additionalFirstPurchase = row.first_purchase_time && row.first_purchase_time[additionalItemKey];
+
+          if (items[additionalItemKey]) {
+            additionalItemArray.push(
+              inflictorWithValue(additionalItemKey, formatSeconds(additionalFirstPurchase)),
+            );
+          }
+        }
       }
-    }
-    return (
-      <div className={styles.items}>
-        {itemArray && <div>{itemArray}</div>}
-        {additionalItemArray && <div>{additionalItemArray}</div>}
+      return (
+        <div className={styles.items}>
+          {itemArray && <div>{itemArray}</div>}
+          {additionalItemArray && <div>{additionalItemArray}</div>}
+        </div>
+      );
+    },
+  }, {
+    displayName: (
+      <div style={{ marginLeft: 10 }}>
+        {strings.th_ability_builds}
       </div>
-    );
-  },
-}, {
-  displayName: 'Buffs',
-  field: 'permanent_buffs',
-  displayFn: row => ( // buff.permanent_buff, buff.stack_count
-    row.permanent_buffs && row.permanent_buffs.length > 0
-      ? row.permanent_buffs.map(buff => inflictorWithValue(buffs[buff.permanent_buff], buff.stack_count, 'buff'))
-      : ' - '
-  ),
-  parsed: true,
-}, {
-  displayName: (
-    <div style={{ marginLeft: 10 }}>
-      {strings.th_ability_builds}
-    </div>
-  ),
-  tooltip: strings.tooltip_ability_builds,
-  displayFn: row => (
-    <div data-tip data-for={`au_${row.player_slot}`} className={styles.abilityUpgrades}>
-      {row.ability_upgrades_arr ? <NavigationMoreHoriz /> : <NavigationMoreHoriz style={{ opacity: 0.4 }} />}
-      <ReactTooltip id={`au_${row.player_slot}`} place="left" effect="solid">
-        {row.ability_upgrades_arr ? row.ability_upgrades_arr.map(
-          (ab, i) => {
-            if (ab && !abilityIds[ab].includes('attribute_bonus')) {
-              // Here I hide stat upgrades, if necessary it can be displayed
-              return (
-                <div className={styles.ability}>
-                  {inflictorWithValue(abilityIds[ab], `${strings.th_level} ${i + 1}`)}
-                </div>
-              );
-            }
-            return null;
-          },
-        ) : <div style={{ paddingBottom: 5 }}>{strings.tooltip_ability_builds_expired}</div>}
-      </ReactTooltip>
-    </div>
-  ),
-}];
+    ),
+    tooltip: strings.tooltip_ability_builds,
+    displayFn: row => (
+      <div data-tip data-for={`au_${row.player_slot}`} className={styles.abilityUpgrades}>
+        {row.ability_upgrades_arr ? <NavigationMoreHoriz /> : <NavigationMoreHoriz style={{ opacity: 0.4 }} />}
+        <ReactTooltip id={`au_${row.player_slot}`} place="left" effect="solid">
+          {row.ability_upgrades_arr ? row.ability_upgrades_arr.map(
+            (ab, i) => {
+              if (ab && !abilityIds[ab].includes('attribute_bonus')) {
+                // Here I hide stat upgrades, if necessary it can be displayed
+                return (
+                  <div className={styles.ability}>
+                    {inflictorWithValue(abilityIds[ab], `${strings.th_level} ${i + 1}`)}
+                  </div>
+                );
+              }
+              return null;
+            },
+          ) : <div style={{ paddingBottom: 5 }}>{strings.tooltip_ability_builds_expired}</div>}
+        </ReactTooltip>
+      </div>
+    ),
+  }];
+
+  if (match.players.map(player => player.permanent_buffs && player.permanent_buffs.length).reduce(sum) > 0) {
+    cols.splice(cols.length - 1, 0, {
+      displayName: strings.th_permanent_buffs,
+      field: 'permanent_buffs',
+      displayFn: row => (
+        row.permanent_buffs && row.permanent_buffs.length > 0
+          ? row.permanent_buffs.map(buff => inflictorWithValue(buffs[buff.permanent_buff], buff.stack_count, 'buff'))
+          : '-'
+      ),
+    });
+  }
+
+  return cols;
+};
 
 export const benchmarksColumns = (match) => {
   const cols = [

--- a/src/components/Match/matchColumns.jsx
+++ b/src/components/Match/matchColumns.jsx
@@ -196,16 +196,15 @@ export const overviewColumns = (match) => {
     },
   }]
   .concat(
-    match.players.map(player => player.permanent_buffs && player.permanent_buffs.length).reduce(sum, 0) > 0 &&
-      {
-        displayName: strings.th_permanent_buffs,
-        field: 'permanent_buffs',
-        displayFn: row => (
-          row.permanent_buffs && row.permanent_buffs.length > 0
-            ? row.permanent_buffs.map(buff => inflictorWithValue(buffs[buff.permanent_buff], buff.stack_count, 'buff'))
-            : '-'
-        ),
-      },
+    match.players.map(player => player.permanent_buffs && player.permanent_buffs.length).reduce(sum, 0) > 0 ? {
+      displayName: strings.th_permanent_buffs,
+      field: 'permanent_buffs',
+      displayFn: row => (
+        row.permanent_buffs && row.permanent_buffs.length > 0
+          ? row.permanent_buffs.map(buff => inflictorWithValue(buffs[buff.permanent_buff], buff.stack_count, 'buff'))
+          : '-'
+      ),
+    } : {},
   )
   .concat({
     displayName: (

--- a/src/components/Match/matchColumns.jsx
+++ b/src/components/Match/matchColumns.jsx
@@ -204,7 +204,7 @@ export const overviewColumns = (match) => {
           ? row.permanent_buffs.map(buff => inflictorWithValue(buffs[buff.permanent_buff], buff.stack_count, 'buff'))
           : '-'
       ),
-    } : {},
+    } : [],
   )
   .concat({
     displayName: (

--- a/src/components/Visualizations/inflictorWithValue.css
+++ b/src/components/Visualizations/inflictorWithValue.css
@@ -119,3 +119,21 @@
     }
   }
 }
+
+.buff {
+  width: 29px;
+  height: 29px;
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: cover;
+  box-shadow: 0 0 5px var(--defaultPrimaryColor);
+}
+
+.buffOverlay {
+  position: absolute;
+  bottom: 0;
+  right: 2px;
+  color: var(--textColorPrimary);
+  font-weight: var(--fontWeightMedium);
+  text-shadow: 1px 1px 2px black, -1px -1px 2px black;
+}

--- a/src/components/Visualizations/inflictorWithValue.jsx
+++ b/src/components/Visualizations/inflictorWithValue.jsx
@@ -49,7 +49,7 @@ const tooltipContainer = thing => (
   </div>
 );
 
-export default (inflictor, value) => {
+export default (inflictor, value, type) => {
   if (inflictor !== undefined) {
     // TODO use abilities if we need the full info immediately
     const ability = abilities[inflictor];
@@ -69,8 +69,21 @@ export default (inflictor, value) => {
     }
     return (
       <div className={styles.inflictorWithValue} data-tip={tooltip && true} data-for={ttId}>
-        <img src={image} role="presentation" />
-        <div className={styles.overlay}>{value}</div>
+        {!type && <img src={image} role="presentation" />}
+        {type === 'buff' &&
+          <div
+            className={styles.buff}
+            style={{
+              backgroundImage: `url(${image})`,
+            }}
+          />
+        }
+        {!type && <div className={styles.overlay}>{value}</div>}
+        {type === 'buff' &&
+          <div className={styles.buffOverlay}>
+            {value > 0 && value}
+          </div>
+        }
         {tooltip &&
         <div className={styles.tooltip}>
           <ReactTooltip id={ttId} effect="solid" place="left">

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -362,6 +362,7 @@
   "th_solo_mmr": "Solo MMR",
   "th_party_mmr": "Party MMR",
   "th_estimated_mmr": "Estimated MMR",
+  "th_permanent_buffs": "Buffs",
 
   "time_just_now": "just now",
   "time_second": "second",


### PR DESCRIPTION
fixes #450 

![image](https://cloud.githubusercontent.com/assets/20866892/20216017/ba56bad8-a820-11e6-8be6-ea35c345813b.png)

Need some hint how to hide this column properly for unparsed matches and matches that have no data about permanent_buffs