### PR TITLE
eslint: allow same precedence operators to be mix

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -20,6 +20,9 @@
     "import/named": 2,
     "import/no-dynamic-require": 0,
     "jsx-a11y/no-static-element-interactions": [0],
-    "react/forbid-prop-types": [2, { "forbid": ["any"] }]
+    "react/forbid-prop-types": [2, { "forbid": ["any"] }],
+    "no-mixed-operators": ["error", {
+      "allowSamePrecedence": true
+    }]
   }
 }


### PR DESCRIPTION
See http://eslint.org/docs/rules/no-mixed-operators.

`10 * (a - b) / 10 * (a - c)` will now be valid.