### PR TITLE
add credentials to all requests

### DIFF
--- a/src/actions/asyncActionsFactory.js
+++ b/src/actions/asyncActionsFactory.js
@@ -32,7 +32,7 @@
 //     } else {
 //       dispatch(getPlayerRequest(accountId));
 //     }
-//     return fetch(`${host}${url}/${accountId}`)
+//     return fetch(`${host}${url}/${accountId}`, { credentials: 'include' })
 //       .then(response => response.json(accountId))
 //       .then(json => {
 //         dispatch(getPlayerOk(json, accountId));

--- a/src/actions/benchmarkActions.js
+++ b/src/actions/benchmarkActions.js
@@ -29,7 +29,7 @@ const getBenchmarkError = payload => ({
 
 const getBenchmark = heroId => (dispatch) => {
   dispatch(getBenchmarkStart());
-  return fetch(`${API_HOST}${url}?hero_id=${heroId}`)
+  return fetch(`${API_HOST}${url}?hero_id=${heroId}`, { credentials: 'include' })
     .then(res => res.json())
     .then(json => dispatch(getBenchmarkDone(json)))
     .catch(err => dispatch(getBenchmarkError(err)));

--- a/src/actions/distributionsActions.js
+++ b/src/actions/distributionsActions.js
@@ -29,7 +29,7 @@ const getDistributionsError = payload => ({
 
 const getDistributions = () => (dispatch) => {
   dispatch(getDistributionsRequest());
-  return fetch(`${API_HOST}${url}`)
+  return fetch(`${API_HOST}${url}`, { credentials: 'include' })
     .then(res => res.json())
     .then(json => dispatch(getDistributionsOk(json)))
     .catch(err => dispatch(getDistributionsError(err)));

--- a/src/actions/matchActions.js
+++ b/src/actions/matchActions.js
@@ -37,7 +37,7 @@ export const setMatchSort = (sortField, sortState, sortFn) => ({
 
 export const getMatch = matchId => (dispatch) => {
   dispatch(getMatchRequest());
-  return fetch(`${API_HOST}${url}${matchId}`)
+  return fetch(`${API_HOST}${url}${matchId}`, { credentials: 'include' })
     .then(response => response.json())
     .then(json => renderMatch(json))
     .then(json => dispatch(getMatchOk(json)))

--- a/src/actions/player/playerActions.js
+++ b/src/actions/player/playerActions.js
@@ -35,7 +35,7 @@ export const getPlayer = accountId => (dispatch, getState) => {
   } else {
     dispatch(getPlayerRequest(accountId));
   }
-  return fetch(`${API_HOST}${url}/${accountId}`)
+  return fetch(`${API_HOST}${url}/${accountId}`, { credentials: 'include' })
     .then(response => response.json(accountId))
     .then((json) => {
       dispatch(getPlayerOk(json, accountId));

--- a/src/actions/rankingActions.js
+++ b/src/actions/rankingActions.js
@@ -29,7 +29,7 @@ const getRankingError = payload => ({
 
 const getRanking = heroId => (dispatch) => {
   dispatch(getRankingStart());
-  return fetch(`${API_HOST}${url}?hero_id=${heroId}`)
+  return fetch(`${API_HOST}${url}?hero_id=${heroId}`, { credentials: 'include' })
     .then(res => res.json())
     .then(json => dispatch(getRankingDone(json)))
     .catch(err => dispatch(getRankingError(err)));

--- a/src/actions/requestActions.js
+++ b/src/actions/requestActions.js
@@ -36,7 +36,7 @@ const requestProgress = progress => ({
 });
 
 function poll(dispatch, json, matchId) {
-  fetch(`${API_HOST}${url}/${json.job.jobId}`)
+  fetch(`${API_HOST}${url}/${json.job.jobId}`, { credentials: 'include' })
   .then(res => res.json())
   .then((json) => {
     if (json.progress) {
@@ -56,6 +56,7 @@ const requestSubmit = matchId => (dispatch) => {
   dispatch(requestRequest());
   return fetch(`${API_HOST}${url}/${matchId}`, {
     method: 'post',
+    credentials: 'include',
   })
   .then(res => res.json())
   .then((json) => {

--- a/src/actions/searchActions.js
+++ b/src/actions/searchActions.js
@@ -37,7 +37,7 @@ const getSearchError = payload => ({
 const getSearchResult = query => (dispatch) => {
   dispatch(getSearchRequest());
   dispatch(setSearchQuery(query));
-  return fetch(`${API_HOST}${url}?q=${query}`)
+  return fetch(`${API_HOST}${url}?q=${query}`, { credentials: 'include' })
     .then(res => res.json())
     .then(json => dispatch(getSearchOk(json)))
     .catch(err => dispatch(getSearchError(err)));

--- a/src/components/Explorer/Explorer.jsx
+++ b/src/components/Explorer/Explorer.jsx
@@ -110,7 +110,7 @@ class Explorer extends React.Component
     this.setState(Object.assign({}, this.state, { loading: true }));
     const queryString = `?sql=${encodeURIComponent(this.editor.getSelectedText() || this.editor.getValue())}`;
     window.history.pushState('', '', queryString);
-    fetch(`${API_HOST}/api/explorer${queryString}`).then(jsonResponse).then(this.handleResponse);
+    fetch(`${API_HOST}/api/explorer${queryString}`, { credentials: 'include' }).then(jsonResponse).then(this.handleResponse);
   }
   handleResponse(json) {
     this.setState(Object.assign({}, this.state, {

--- a/src/components/Player/Header/PlayerButtons.jsx
+++ b/src/components/Player/Header/PlayerButtons.jsx
@@ -26,7 +26,7 @@ class PlayerButtons extends React.Component {
             icon={<ActionUpdate />}
             disabled={this.state.disableRefresh}
             onClick={() => {
-              fetch(`${API_HOST}/api/players/${playerId}/refresh`, { method: 'POST' });
+              fetch(`${API_HOST}/api/players/${playerId}/refresh`, { method: 'POST', credentials: 'include' });
               this.setState({ disableRefresh: true });
             }}
           />

--- a/src/components/Status/Status.jsx
+++ b/src/components/Status/Status.jsx
@@ -22,7 +22,7 @@ class Status extends React.Component
       loading: false,
       result: {},
     });
-    fetch(`${API_HOST}/api/status`).then(jsonResponse).then(json => this.setState({ loading: false, result: json }));
+    fetch(`${API_HOST}/api/status`, { credentials: 'include' }).then(jsonResponse).then(json => this.setState({ loading: false, result: json }));
   }
   render() {
     return (<div style={{ display: 'flex', flexDirection: 'row', flexWrap: 'wrap' }}>


### PR DESCRIPTION
I don't think it's necessary to send credentials for requests except for metadata (which contains login state).

However, @arandomb reports interestingly ( #482 ) that the metadata endpoint appears to work, while the match one does not (and match does not send credentials).  Maybe sending the credentials makes it work, in which case we may as well send them.