### PR TITLE
scrolling fixes for mobile

### DIFF
--- a/src/components/Match/CrossTable.jsx
+++ b/src/components/Match/CrossTable.jsx
@@ -16,7 +16,7 @@ const CrossTable = ({
   field1,
   field2,
 }) => (
-  <Table selectable={false}>
+  <Table style={{ overflowY: 'hidden', overflowX: 'auto' }} selectable={false}>
     <TableBody displayRowCheckbox={false}>
       <TableRow>
         <TableRowColumn />

--- a/src/components/Match/CrossTable.jsx
+++ b/src/components/Match/CrossTable.jsx
@@ -16,7 +16,7 @@ const CrossTable = ({
   field1,
   field2,
 }) => (
-  <Table style={{ overflowY: 'hidden', overflowX: 'auto' }} selectable={false}>
+  <Table selectable={false}>
     <TableBody displayRowCheckbox={false}>
       <TableRow>
         <TableRowColumn />

--- a/src/components/Match/Match.css
+++ b/src/components/Match/Match.css
@@ -343,3 +343,13 @@
   }
 }
 
+.flexContainer {
+  display: flex;
+  flex-wrap: wrap;
+  overflow: auto;
+}
+
+.flexElement {
+  flex: 1;
+  margin-right: 5px;
+}

--- a/src/components/Match/matchColumns.jsx
+++ b/src/components/Match/matchColumns.jsx
@@ -618,20 +618,16 @@ export const objectiveDamageColumns = [heroTdColumn]
     })));
 
 
-export const inflictorsColumns = [{
-  displayName: strings.th_damage_received,
-  field: 'damage_inflictor_received',
-  displayFn: (row, col, field) => (field ? Object.keys(field)
-      .sort((a, b) => field[b] - field[a])
-      .map(inflictor => inflictorWithValue(inflictor, abbreviateNumber(field[inflictor]))) : ''),
-}, {
-  displayFn: () => '→',
-},
+export const inflictorsColumns = [
   heroTdColumn, {
-    displayFn: () => '→',
-  }, {
     displayName: strings.th_damage_dealt,
     field: 'damage_inflictor',
+    displayFn: (row, col, field) => (field ? Object.keys(field)
+      .sort((a, b) => field[b] - field[a])
+      .map(inflictor => inflictorWithValue(inflictor, abbreviateNumber(field[inflictor]))) : ''),
+  }, {
+    displayName: strings.th_damage_received,
+    field: 'damage_inflictor_received',
     displayFn: (row, col, field) => (field ? Object.keys(field)
       .sort((a, b) => field[b] - field[a])
       .map(inflictor => inflictorWithValue(inflictor, abbreviateNumber(field[inflictor]))) : ''),

--- a/src/components/Match/matchPages.jsx
+++ b/src/components/Match/matchPages.jsx
@@ -10,7 +10,6 @@ import {
 } from 'material-ui/Tabs';
 import Heading from 'components/Heading';
 import Table from 'components/Table';
-import { Row, Col } from 'react-flexbox-grid';
 import { IconRadiant, IconDire } from 'components/Icons';
 import VisionPage from './VisionPage';
 import CastTable from './CastTable';
@@ -129,31 +128,27 @@ const matchPages = [{
   name: strings.tab_performances,
   key: 'performances',
   parsed: true,
-  content: match => (<Row>
-    <Col md={12}>
-      <TeamTable match={match} columns={performanceColumns} heading={strings.heading_performances} />
-    </Col>
-    <Col md={12}>
-      <TeamTable match={match} columns={supportColumns} heading={strings.heading_support} />
-    </Col>
-  </Row>),
+  content: match => (<div>
+    <TeamTable match={match} columns={performanceColumns} heading={strings.heading_performances} />
+    <TeamTable match={match} columns={supportColumns} heading={strings.heading_support} />
+  </div>),
 }, {
   name: strings.tab_combat,
   key: 'combat',
   parsed: true,
-  content: match => (<Row>
-    <Col md={6}>
-      <Heading title={strings.heading_kills} />
-      <CrossTable match={match} field1="killed" field2="killed_by" />
-    </Col>
-    <Col md={6}>
-      <Heading title={strings.heading_damage} />
-      <CrossTable match={match} field1="damage" field2="damage_taken" />
-    </Col>
-    <Col md={12}>
-      <TeamTable match={match} columns={inflictorsColumns} heading={strings.heading_damage} />
-    </Col>
-  </Row>),
+  content: match => (<div>
+    <div style={{ display: 'flex', flexWrap: 'wrap', overflow: 'auto' }}>
+      <div style={{ flex: 1, marginRight: '5px' }}>
+        <Heading title={strings.heading_kills} />
+        <CrossTable match={match} field1="killed" field2="killed_by" />
+      </div>
+      <div style={{ flex: 1, marginRight: '5px' }}>
+        <Heading title={strings.heading_damage} />
+        <CrossTable match={match} field1="damage" field2="damage_taken" />
+      </div>
+    </div>
+    <TeamTable match={match} columns={inflictorsColumns} heading={strings.heading_damage} />
+  </div>),
 }, {
   name: strings.tab_farm,
   key: 'farm',
@@ -161,14 +156,14 @@ const matchPages = [{
   content: match => (<div>
     <TeamTable match={match} columns={unitKillsColumns} heading={strings.heading_unit_kills} />
     <TeamTable match={match} columns={lastHitsTimesColumns(match)} heading={strings.heading_last_hits} />
-    <Row>
-      <Col md={7}>
+    <div style={{ display: 'flex', flexWrap: 'wrap', overflow: 'auto' }}>
+      <div style={{ flex: 1, marginRight: '5px' }}>
         <TeamTable match={match} columns={goldReasonsColumns} heading={strings.heading_gold_reasons} />
-      </Col>
-      <Col md={5}>
+      </div>
+      <div style={{ flex: 1, marginRight: '5px' }}>
         <TeamTable match={match} columns={xpReasonsColumns} heading={strings.heading_xp_reasons} />
-      </Col>
-    </Row>
+      </div>
+    </div>
   </div>),
 }, {
   name: strings.tab_purchases,

--- a/src/components/Match/matchPages.jsx
+++ b/src/components/Match/matchPages.jsx
@@ -137,12 +137,12 @@ const matchPages = [{
   key: 'combat',
   parsed: true,
   content: match => (<div>
-    <div style={{ display: 'flex', flexWrap: 'wrap', overflow: 'auto' }}>
-      <div style={{ flex: 1, marginRight: '5px' }}>
+    <div className={styles.flexContainer}>
+      <div className={styles.flexElement}>
         <Heading title={strings.heading_kills} />
         <CrossTable match={match} field1="killed" field2="killed_by" />
       </div>
-      <div style={{ flex: 1, marginRight: '5px' }}>
+      <div className={styles.flexElement}>
         <Heading title={strings.heading_damage} />
         <CrossTable match={match} field1="damage" field2="damage_taken" />
       </div>
@@ -156,11 +156,11 @@ const matchPages = [{
   content: match => (<div>
     <TeamTable match={match} columns={unitKillsColumns} heading={strings.heading_unit_kills} />
     <TeamTable match={match} columns={lastHitsTimesColumns(match)} heading={strings.heading_last_hits} />
-    <div style={{ display: 'flex', flexWrap: 'wrap', overflow: 'auto' }}>
-      <div style={{ flex: 1, marginRight: '5px' }}>
+    <div className={styles.flexContainer}>
+      <div className={styles.flexElement}>
         <TeamTable match={match} columns={goldReasonsColumns} heading={strings.heading_gold_reasons} />
       </div>
-      <div style={{ flex: 1, marginRight: '5px' }}>
+      <div className={styles.flexElement}>
         <TeamTable match={match} columns={xpReasonsColumns} heading={strings.heading_xp_reasons} />
       </div>
     </div>


### PR DESCRIPTION
fixes #312 

I identified that using react-flexbox-grid on match table components was breaking the scrolling on mobile.  I adapted some of the ideas from #313 to solve this.

Also rearranged damage inflictors to save some space

Reviewers:
@mike-robertson 
@blukai 