### PR TITLE
Change hero images to hero icons in building map tooltips

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "c3": "^0.4.11",
     "classnames": "^2.2.5",
     "color": "^0.11.4",
-    "dotaconstants": "^3.6.0",
+    "dotaconstants": "^3.7.0",
     "flag-icon-css": "^2.8.0",
     "flexboxgrid": "^6.3.1",
     "heatmap.js": "^2.0.5",

--- a/src/components/Match/BuildingMap/BuildingMap.css
+++ b/src/components/Match/BuildingMap/BuildingMap.css
@@ -54,7 +54,8 @@
 
 .damage {
   & > div > img {
-    width: 24px;
+    margin: 0 5px;
+    width: 14px;
     height: 14px;
     vertical-align: sub;
     filter: drop-shadow(0 0 2px rgba(255, 255, 255, 0.2));
@@ -92,6 +93,7 @@
     }
 
     & img {
+      margin: 0;
       width: 24px;
       height: 14px;
       display: inline-block;

--- a/src/components/Match/BuildingMap/BuildingMap.jsx
+++ b/src/components/Match/BuildingMap/BuildingMap.jsx
@@ -133,7 +133,7 @@ export default function BuildingMap({ match }) {
                     {damage.map(player => (
                       <div key={player.hero_id}>
                         <img
-                          src={heroes[player.hero_id] && API_HOST + heroes[player.hero_id].img}
+                          src={heroes[player.hero_id] && API_HOST + heroes[player.hero_id].icon}
                           role="presentation"
                         />
                         <span className={styles.damageValue}>


### PR DESCRIPTION
fixes #498 

Fixes issue #498 
Reference to .icon vs .image and adjusted styles. Updated package.json reference to newest version of dotaconstants.

Icons look a little small imo, but I'll leave that open for feedback.
![heroicons](https://cloud.githubusercontent.com/assets/1359826/20655842/934b1034-b4f4-11e6-9c0a-80a114c47e7e.jpg)
