### PR TITLE
Update PlayerThumb to use icon url from dotaconstants

### DIFF
--- a/src/components/Match/PlayerThumb/index.jsx
+++ b/src/components/Match/PlayerThumb/index.jsx
@@ -10,7 +10,7 @@ const PlayerThumb = ({ player_slot, hero_id, name, personaname }) => (
     <img
       className={styles.heroThumb}
       src={heroes[hero_id]
-        ? `${API_HOST}/apps/dota2/images/heroes/${getShortHeroName(heroes[hero_id].name)}_icon.png`
+        ? `${API_HOST}${heroes[hero_id].icon}`
         : '/assets/images/blank-1x1.gif'
       }
       role="presentation"

--- a/src/components/Match/PlayerThumb/index.jsx
+++ b/src/components/Match/PlayerThumb/index.jsx
@@ -1,7 +1,6 @@
 import React, { PropTypes } from 'react';
 import playerColors from 'dotaconstants/json/player_colors.json';
 import heroes from 'dotaconstants/json/heroes.json';
-import { getShortHeroName } from 'utility';
 import strings from 'lang';
 import styles from './PlayerThumb.css';
 

--- a/src/utility/index.jsx
+++ b/src/utility/index.jsx
@@ -399,5 +399,3 @@ export const threshold = _.curry((start, limits, values, value) => {
   limitsWithStart.unshift(start);
   return findLast(values, (v, i) => _.inRange(limitsWithStart[i], limitsWithStart[i + 1], value));
 });
-
-export const getShortHeroName = name => name.split('npc_dota_hero_')[1];


### PR DESCRIPTION
Updating PlayerThumb for consistency with new reference method for hero icons.