### PR TITLE
remove duplicated support data, other fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "brace": "^0.9.0",
     "c3": "^0.4.11",
     "classnames": "^2.2.5",
-    "dotaconstants": "^4.3.0",
+    "dotaconstants": "^4.5.0",
     "flag-icon-css": "^2.8.0",
     "flexboxgrid": "^6.3.1",
     "fuzzy": "^0.1.3",

--- a/src/components/Match/matchColumns.jsx
+++ b/src/components/Match/matchColumns.jsx
@@ -211,7 +211,7 @@ export const overviewColumns = (match) => {
               if (ab && abilityIds[ab]) {
                 return (
                   <div className={styles.ability}>
-                    {inflictorWithValue(abilityIds[ab], `${strings.th_level} ${i + 1}`)}
+                    {inflictorWithValue(abilityIds[ab])}
                   </div>
                 );
               }
@@ -349,6 +349,12 @@ export const performanceColumns = [
     field: 'stuns',
     sortFn: true,
     displayFn: (row, col, field) => (field ? field.toFixed(2) : '-'),
+  }, {
+    displayName: strings.th_stacked,
+    tooltip: strings.tooltip_camps_stacked,
+    field: 'camps_stacked',
+    sortFn: true,
+    displayFn: (row, col, field) => field || '-',
   }, {
     displayName: strings.th_dead,
     tooltip: strings.tooltip_dead,
@@ -780,28 +786,5 @@ export const visionColumns = [
     sortFn: true,
     displayFn: row => (row.item_uses && row.item_uses.smoke_of_deceit) || '-',
   },
-  purchaseGemColumn,
-];
-
-export const supportColumns = [
-  heroTdColumn, {
-    center: true,
-    displayName: strings.th_stacked,
-    tooltip: strings.tooltip_camps_stacked,
-    field: 'camps_stacked',
-    sortFn: true,
-    displayFn: (row, col, field) => field || '-',
-  }, {
-    center: true,
-    displayName: strings.th_tpscroll,
-    tooltip: strings.tooltip_purchase_tpscroll,
-    field: 'purchase_tpscroll',
-    sortFn: true,
-    displayFn: (row, col, field) => field || '-',
-  },
-  purchaseObserverColumn,
-  purchaseSentryColumn,
-  purchaseDustColumn,
-  purchaseSmokeColumn,
   purchaseGemColumn,
 ];

--- a/src/components/Match/matchColumns.jsx
+++ b/src/components/Match/matchColumns.jsx
@@ -207,7 +207,7 @@ export const overviewColumns = (match) => {
         {row.ability_upgrades_arr ? <NavigationMoreHoriz /> : <NavigationMoreHoriz style={{ opacity: 0.4 }} />}
         <ReactTooltip id={`au_${row.player_slot}`} place="left" effect="solid">
           {row.ability_upgrades_arr ? row.ability_upgrades_arr.map(
-            (ab, i) => {
+            (ab) => {
               if (ab && abilityIds[ab]) {
                 return (
                   <div className={styles.ability}>

--- a/src/components/Match/matchPages.jsx
+++ b/src/components/Match/matchPages.jsx
@@ -9,10 +9,8 @@ import CrossTable from './CrossTable';
 import MatchGraph from './MatchGraph';
 import MatchLog from './MatchLog';
 import {
-  // abilityUpgradeColumns,
   benchmarksColumns,
   performanceColumns,
-  supportColumns,
   chatColumns,
   purchaseTimesColumns,
   lastHitsTimesColumns,
@@ -46,10 +44,6 @@ const matchPages = [Overview, {
   content: match => (<div>
     <TeamTable
       players={match.players} columns={performanceColumns} heading={strings.heading_performances}
-      radiantTeam={match.radiant_team} direTeam={match.dire_team}
-    />
-    <TeamTable
-      players={match.players} columns={supportColumns} heading={strings.heading_support}
       radiantTeam={match.radiant_team} direTeam={match.dire_team}
     />
   </div>),


### PR DESCRIPTION
fixes #602 

* Removes level numbers from ability builds
* Bump min version of dotaconstants to 4.5.0
* remove support section from performances (data already in vision tab)