### PR TITLE
fix roshan timeline crash

### DIFF
--- a/src/components/Match/Overview/Timeline.jsx
+++ b/src/components/Match/Overview/Timeline.jsx
@@ -32,9 +32,6 @@ const Timeline = ({
 }) => {
   const preHorn = 90; // Seconds before the battle horn
 
-  const obj = [];
-  const aegis = [];
-
   if (match.objectives && match.objectives.length > 0) {
     // Firstblood
     const fbIndex = match.objectives.findIndex(obj => obj.type === 'CHAT_MESSAGE_FIRSTBLOOD');
@@ -55,7 +52,7 @@ const Timeline = ({
       }];
     }
 
-    obj.push(fbArr
+    const events = fbArr
 
     // Roshan kills, team 2 = radiant, 3 = dire
     .concat(
@@ -84,12 +81,10 @@ const Timeline = ({
           } : ''))
           .filter(String),
       })) : [],
-    ),
     );
 
     // Aegis pickups
-    aegis.push(
-      match.objectives
+    const aegis = (match.objectives || [])
         .filter(obj => (
           obj.type === 'CHAT_MESSAGE_AEGIS' ||
             obj.type === 'CHAT_MESSAGE_AEGIS_STOLEN' ||
@@ -103,8 +98,7 @@ const Timeline = ({
           ),
           time: obj.time,
           player_slot: obj.player_slot,
-        })) || [],
-    );
+        }));
 
     let fTower = match.objectives.findIndex(o => o.type === 'CHAT_MESSAGE_TOWER_KILL' || o.type === 'CHAT_MESSAGE_TOWER_DENY');
     fTower = match.objectives[fTower] ? match.objectives[fTower].time : null;
@@ -113,7 +107,7 @@ const Timeline = ({
     fRax = match.objectives[fRax] || null;
 
     return (
-      Math.abs(obj[0].filter(obj => obj.type === 'firstblood')[0].time - match.first_blood_time) <= preHorn &&
+      Math.abs(events.filter(obj => obj.type === 'firstblood')[0].time - match.first_blood_time) <= preHorn &&
       // some old (source1) matches have wrong time in objectives, ex: 271008789.
       // preHorn (90) is just small allowable mismatch. Since first_blood_time always >= 0, ex: 2792706825, fb before battle horn
       <div>
@@ -135,7 +129,7 @@ const Timeline = ({
                 }}
               />
               {
-                obj[0].map((obj, i) => {
+                events.map((obj, i) => {
                   const side = (
                     obj.player_slot && isRadiant(obj.player_slot))
                       || (obj.team && obj.team === 2
@@ -207,16 +201,16 @@ const Timeline = ({
                             }
                           </section>
                         }
-                        {obj.type === 'roshan' &&
+                        {obj.type === 'roshan' && aegis[obj.key] &&
                           match.players
-                            .filter(player => player.player_slot === aegis[0][obj.key].player_slot)
+                            .filter(player => player.player_slot === aegis[obj.key].player_slot)
                             .map(player => (
                               <section key={i}>
                                 <PlayerThumb {...player} />
                                 <span>
-                                  {!aegis[0][obj.key].act && strings.timeline_aegis_picked_up}
-                                  {aegis[0][obj.key].act === 'stolen' && strings.timeline_aegis_snatched}
-                                  {aegis[0][obj.key].act === 'denied' && strings.timeline_aegis_denied}
+                                  {!aegis[obj.key].act && strings.timeline_aegis_picked_up}
+                                  {aegis[obj.key].act === 'stolen' && strings.timeline_aegis_snatched}
+                                  {aegis[obj.key].act === 'denied' && strings.timeline_aegis_denied}
                                 </span>
                                 <img
                                   src="/assets/images/dota2/aegis_icon.png"


### PR DESCRIPTION
fixes #652 

Apparently there's no more key data for Roshan kills.  This is causing aegis[0][obj.key] to be undefined, and we try to read player_slot from it.

I also removed the [0] bits from the obj and aegis arrays since it seemed like there was no reason to have an array of arrays there.

Also renamed obj to events to make it clearer.