### PR TITLE
Hide text of player header buttons on mobile

### DIFF
--- a/src/components/Form/ShowFormToggle.jsx
+++ b/src/components/Form/ShowFormToggle.jsx
@@ -21,7 +21,7 @@ const ShowFormToggle = ({ toggleShowForm, showForm }) => (
   <FlatButton onClick={() => toggleShowForm()}>
     <div className={styles.container}>
       {getIcon(showForm)}
-      {showForm ? strings.filter_button_text_close : strings.filter_button_text_open}
+      <span>{showForm ? strings.filter_button_text_close : strings.filter_button_text_open}</span>
     </div>
   </FlatButton>
 );

--- a/src/components/Player/Header/PlayerButtons.css
+++ b/src/components/Player/Header/PlayerButtons.css
@@ -6,6 +6,24 @@
 
   @media only screen and (max-width: 660px) {
     justify-content: center;
+
+    & a {
+      min-width: 50px !important;
+    }
+
+    & button {
+      min-width: 50px !important;
+    }
+
+    & * {
+      font-size: 0 !important;
+      padding: 0 !important;
+      margin: auto !important;
+    }
+
+    & span {
+      margin: 0 !important;
+    }
   }
 }
 
@@ -31,5 +49,9 @@
       margin-bottom: 6px;
       margin-left: -50px;
     }
+  }
+
+  @media only screen and (max-width: 660px) {
+    padding-right: 0 !important;
   }
 }


### PR DESCRIPTION
fixes #686 

Like Match page, text next to all buttons are hidden on mobile screens.