### PR TITLE
add sum functionality to tables

### DIFF
--- a/src/components/Match/matchColumns.jsx
+++ b/src/components/Match/matchColumns.jsx
@@ -158,8 +158,8 @@ export const overviewColumns = (match) => {
       </span>
     ),
     tooltip: strings.tooltip_gold,
-    field: 'gold_per_min',
-    displayFn: row => abbreviateNumber((row.gold_per_min * row.duration) / 60),
+    field: 'total_gold',
+    displayFn: row => abbreviateNumber(row.total_gold),
     sortFn: true,
     color: styles.golden,
     sumFn: true,

--- a/src/components/Match/matchColumns.jsx
+++ b/src/components/Match/matchColumns.jsx
@@ -84,61 +84,72 @@ export const overviewColumns = (match) => {
     field: 'level',
     sortFn: true,
     maxFn: true,
+    sumFn: true,
   }, {
     displayName: strings.th_kills,
     tooltip: strings.tooltip_kills,
     field: 'kills',
     sortFn: true,
     displayFn: transformations.kda,
+    sumFn: true,
   }, {
     displayName: strings.th_deaths,
     tooltip: strings.tooltip_deaths,
     field: 'deaths',
     sortFn: true,
+    sumFn: true,
   }, {
     displayName: strings.th_assists,
     tooltip: strings.tooltip_assists,
     field: 'assists',
     sortFn: true,
+    sumFn: true,
   }, {
     displayName: strings.th_gold_per_min,
     tooltip: strings.tooltip_gold_per_min,
     field: 'gold_per_min',
     sortFn: true,
     color: styles.golden,
+    sumFn: true,
   }, {
     displayName: strings.th_xp_per_min,
     tooltip: strings.tooltip_xp_per_min,
     field: 'xp_per_min',
     sortFn: true,
+    sumFn: true,
   }, {
     displayName: strings.th_last_hits,
     tooltip: strings.tooltip_last_hits,
     field: 'last_hits',
     sortFn: true,
+    sumFn: true,
   }, {
     displayName: strings.th_denies,
     tooltip: strings.tooltip_denies,
     field: 'denies',
     sortFn: true,
+    sumFn: true,
   }, {
     displayName: strings.th_hero_damage,
     tooltip: strings.tooltip_hero_damage,
     field: 'hero_damage',
     displayFn: row => abbreviateNumber(row.hero_damage),
     sortFn: true,
+    sumFn: true,
   }, {
     displayName: strings.th_hero_healing,
     tooltip: strings.tooltip_hero_healing,
     field: 'hero_healing',
     displayFn: row => abbreviateNumber(row.hero_healing),
     sortFn: true,
+    sumFn: true,
   }, {
     displayName: strings.th_tower_damage,
     tooltip: strings.tooltip_tower_damage,
     field: 'tower_damage',
     displayFn: row => abbreviateNumber(row.tower_damage),
     sortFn: true,
+    sumFn: true,
   }, {
     displayName: (
       <span className={styles.thGold}>
@@ -151,6 +162,7 @@ export const overviewColumns = (match) => {
     displayFn: row => abbreviateNumber((row.gold_per_min * row.duration) / 60),
     sortFn: true,
     color: styles.golden,
+    sumFn: true,
   }, {
     displayName: strings.th_items,
     tooltip: strings.tooltip_items,

--- a/src/components/Match/renderMatch.js
+++ b/src/components/Match/renderMatch.js
@@ -241,6 +241,7 @@ function renderMatch(m) {
       newPlayer.purchase_gem = player.purchase.gem;
     }
     newPlayer.buybacks = (player.buyback_log || []).length;
+    newPlayer.total_gold = (player.gold_per_min * m.duration) / 60
     return newPlayer;
   });
 

--- a/src/components/Match/renderMatch.js
+++ b/src/components/Match/renderMatch.js
@@ -241,7 +241,7 @@ function renderMatch(m) {
       newPlayer.purchase_gem = player.purchase.gem;
     }
     newPlayer.buybacks = (player.buyback_log || []).length;
-    newPlayer.total_gold = (player.gold_per_min * m.duration) / 60
+    newPlayer.total_gold = (player.gold_per_min * m.duration) / 60;
     return newPlayer;
   });
 

--- a/src/components/Table/Table.jsx
+++ b/src/components/Table/Table.jsx
@@ -9,11 +9,11 @@ import {
   TableRow as MaterialTableRow,
   TableRowColumn as MaterialTableRowColumn,
 } from 'material-ui/Table';
+import { abbreviateNumber } from 'utility';
 import TableHeader from './TableHeader';
 import Spinner from '../Spinner';
 import Error from '../Error';
 import styles from './Table.css';
-import { abbreviateNumber } from 'utility';
 import {
   // getTotalWidth,
   // getWidthStyle,
@@ -48,7 +48,7 @@ const getTable = (data, columns, sortState, sortField, sortClick) => (
               }
 
               return (
-                <MaterialTableRowColumn key={index+'_'+colIndex} style={style}>
+                <MaterialTableRowColumn key={`${index}_${colIndex}`} style={style}>
                   {row && column.displayFn && column.displayFn(row, column, row[column.field], index)}
                   {row && !column.displayFn && row[column.field]}
                 </MaterialTableRowColumn>
@@ -57,11 +57,9 @@ const getTable = (data, columns, sortState, sortField, sortClick) => (
           </MaterialTableRow>
         ))}
         <MaterialTableRow>
-          {columns.map((column, colIndex) => {
-            return (<MaterialTableRowColumn key={colIndex + '_sum'}>
-              {column.sumFn && abbreviateNumber(data.map(row => row[column.field]).reduce((a, b) => a + b, 0))}
-            </MaterialTableRowColumn>);
-          })}
+          {columns.map((column, colIndex) => (<MaterialTableRowColumn key={`${colIndex}_sum`}>
+            {column.sumFn && abbreviateNumber(data.map(row => row[column.field]).reduce((a, b) => a + b, 0))}
+          </MaterialTableRowColumn>))}
         </MaterialTableRow>
       </MaterialTableBody>
     </MaterialTable>

--- a/src/components/Table/Table.jsx
+++ b/src/components/Table/Table.jsx
@@ -9,15 +9,11 @@ import {
   TableRow as MaterialTableRow,
   TableRowColumn as MaterialTableRowColumn,
 } from 'material-ui/Table';
-import { abbreviateNumber } from 'utility';
+import { abbreviateNumber, sum } from 'utility';
 import TableHeader from './TableHeader';
 import Spinner from '../Spinner';
 import Error from '../Error';
 import styles from './Table.css';
-import {
-  // getTotalWidth,
-  // getWidthStyle,
-} from './tableHelpers';
 
 const getTable = (data, columns, sortState, sortField, sortClick) => (
   // Not currently using totalWidth (default auto width)
@@ -57,8 +53,8 @@ const getTable = (data, columns, sortState, sortField, sortClick) => (
           </MaterialTableRow>
         ))}
         <MaterialTableRow>
-          {columns.map((column, colIndex) => (<MaterialTableRowColumn key={`${colIndex}_sum`}>
-            {column.sumFn && abbreviateNumber(data.map(row => row[column.field]).reduce((a, b) => a + b, 0))}
+          {columns.map((column, colIndex) => (<MaterialTableRowColumn key={`${colIndex}_sum`} style={{ color: column.color }}>
+            {column.sumFn && abbreviateNumber(data.map(row => row[column.field]).reduce(sum, 0))}
           </MaterialTableRowColumn>))}
         </MaterialTableRow>
       </MaterialTableBody>

--- a/src/components/Table/Table.jsx
+++ b/src/components/Table/Table.jsx
@@ -13,6 +13,7 @@ import TableHeader from './TableHeader';
 import Spinner from '../Spinner';
 import Error from '../Error';
 import styles from './Table.css';
+import { abbreviateNumber } from 'utility';
 import {
   // getTotalWidth,
   // getWidthStyle,
@@ -47,7 +48,7 @@ const getTable = (data, columns, sortState, sortField, sortClick) => (
               }
 
               return (
-                <MaterialTableRowColumn key={colIndex} style={style}>
+                <MaterialTableRowColumn key={index+'_'+colIndex} style={style}>
                   {row && column.displayFn && column.displayFn(row, column, row[column.field], index)}
                   {row && !column.displayFn && row[column.field]}
                 </MaterialTableRowColumn>
@@ -55,6 +56,13 @@ const getTable = (data, columns, sortState, sortField, sortClick) => (
             })}
           </MaterialTableRow>
         ))}
+        <MaterialTableRow>
+          {columns.map((column, colIndex) => {
+            return (<MaterialTableRowColumn key={colIndex + '_sum'}>
+              {column.sumFn && abbreviateNumber(data.map(row => row[column.field]).reduce((a, b) => a + b, 0))}
+            </MaterialTableRowColumn>);
+          })}
+        </MaterialTableRow>
       </MaterialTableBody>
     </MaterialTable>
   </div>


### PR DESCRIPTION
fixes #191 

* Renders an additional row on tables with sums
* Currently only supports `true` for sumFn.  Custom sum values can be added later if needed (it'll use `row[column.field]` right now
* Only added sums to match overview table for now