### PR TITLE
[RELEASE] 2017-02-09 

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "react-router": "^3.0.0",
     "react-router-redux": "^4.0.7",
     "react-tap-event-plugin": "^2.0.1",
-    "react-tooltip": "^3.2.1",
+    "react-tooltip": "3.2.3",
     "redux": "^3.6.0",
     "redux-logger": "^2.7.4",
     "redux-responsive": "^3.2.0",

--- a/src/components/Match/Overview/Overview.jsx
+++ b/src/components/Match/Overview/Overview.jsx
@@ -21,6 +21,7 @@ export default {
         picksBans={match.picks_bans}
         radiantTeam={match.radiant_team}
         direTeam={match.dire_team}
+        summable={true}
       />
       <div className={styles.overviewMapGraph}>
         <div className={`${styles.map} ${!match.version && styles.centeredMap}`}>

--- a/src/components/Match/Overview/Overview.jsx
+++ b/src/components/Match/Overview/Overview.jsx
@@ -21,7 +21,7 @@ export default {
         picksBans={match.picks_bans}
         radiantTeam={match.radiant_team}
         direTeam={match.dire_team}
-        summable={true}
+        summable
       />
       <div className={styles.overviewMapGraph}>
         <div className={`${styles.map} ${!match.version && styles.centeredMap}`}>

--- a/src/components/Match/TeamTable.jsx
+++ b/src/components/Match/TeamTable.jsx
@@ -18,19 +18,20 @@ export default ({
   picksBans = [],
   radiantTeam = {},
   direTeam = {},
+  summable = false,
 }) => (
   <div>
     <Heading
       title={`${getTeamName(radiantTeam, true)} - ${heading}`}
       icon={<IconRadiant className={styles.iconRadiant} />}
     />
-    <Table data={filterMatchPlayers(players, 'radiant')} columns={columns} />
+    <Table data={filterMatchPlayers(players, 'radiant')} columns={columns} summable={summable} />
     {picksBans && <PicksBans data={picksBans.filter(pb => pb.team === 0)} /> /* team 0 - radiant */}
     <Heading
       title={`${getTeamName(direTeam, false)} - ${heading}`}
       icon={<IconDire className={styles.iconDire} />}
     />
-    <Table data={filterMatchPlayers(players, 'dire')} columns={columns} />
+    <Table data={filterMatchPlayers(players, 'dire')} columns={columns} summable={summable} />
     {picksBans && <PicksBans data={picksBans.filter(pb => pb.team === 1)} /> /* team 1 - dire */}
   </div>
 );

--- a/src/components/Table/Table.jsx
+++ b/src/components/Table/Table.jsx
@@ -15,7 +15,7 @@ import Spinner from '../Spinner';
 import Error from '../Error';
 import styles from './Table.css';
 
-const getTable = (data, columns, sortState, sortField, sortClick) => (
+const getTable = (data, columns, sortState, sortField, sortClick, numRows, summable) => (
   // Not currently using totalWidth (default auto width)
   // const totalWidth = getTotalWidth(columns);
   <div className={styles.innerContainer}>
@@ -52,11 +52,11 @@ const getTable = (data, columns, sortState, sortField, sortClick) => (
             })}
           </MaterialTableRow>
         ))}
-        <MaterialTableRow>
+        {summable && <MaterialTableRow>
           {columns.map((column, colIndex) => (<MaterialTableRowColumn key={`${colIndex}_sum`} style={{ color: column.color }}>
             {column.sumFn && abbreviateNumber(data.map(row => row[column.field]).reduce(sum, 0))}
           </MaterialTableRowColumn>))}
-        </MaterialTableRow>
+        </MaterialTableRow>}
       </MaterialTableBody>
     </MaterialTable>
   </div>
@@ -71,11 +71,12 @@ const Table = ({
   sortField,
   sortClick,
   numRows,
+  summable,
 }) => (
   <div className={styles.container}>
     {loading && <Spinner />}
     {!loading && error && <Error />}
-    {!loading && !error && data && getTable(data, columns, sortState, sortField, sortClick, numRows)}
+    {!loading && !error && data && getTable(data, columns, sortState, sortField, sortClick, numRows, summable)}
   </div>
 );
 
@@ -97,6 +98,7 @@ Table.propTypes = {
   sortField: string,
   sortClick: func,
   numRows: number,
+  summable: bool,
 };
 
 export default Table;


### PR DESCRIPTION
* lock react-tooltip to 3.2.3 (styling messed up with latest version)
* only sum on tables with summable property (prevents extra empty row from showing up)
* rebuild for latest dotaconstants (patch 7.02)