### PR TITLE
ensure announcement only displays new releases

### DIFF
--- a/src/components/Announce/index.jsx
+++ b/src/components/Announce/index.jsx
@@ -67,7 +67,7 @@ class RequestLayer extends React.Component {
           html_url: link,
         } = data.items[0];
 
-        if (localStorage && Number(localStorage.getItem('dismiss')) !== number) {
+        if (localStorage && Number(localStorage.getItem('dismiss')) < number) {
           return <Announce title={title} body={body} onClick={() => this.dismiss(number)} link={link} />;
         }
       }


### PR DESCRIPTION
Only display announcement if localStorage value is less than current announcement.  localStorage.getItem() returns null if key doesn't exist.