### PR TITLE
return top 10 matches for records

### DIFF
--- a/src/actions/player/playerRecordsActions.js
+++ b/src/actions/player/playerRecordsActions.js
@@ -3,7 +3,7 @@ import fetch from 'isomorphic-fetch';
 import { playerRecords } from 'reducers';
 import { getUrl } from 'actions/utility';
 
-const url = playerId => `/api/players/${playerId}/records`;
+const url = playerId => `/api/players/${playerId}/matches`;
 
 const REQUEST = 'playerRecords/REQUEST';
 const OK = 'playerRecords/OK';
@@ -29,25 +29,16 @@ export const getPlayerRecordsError = (payload, id) => ({
   id,
 });
 
-export const getPlayerRecords = (playerId, options = {}) => (dispatch, getState) => {
+export const getPlayerRecords = (playerId, options = {}, subInfo) => (dispatch, getState) => {
+  const modifiedOptions = { ...options, sort: subInfo, limit: 10 };
   if (playerRecords.isLoaded(getState(), playerId)) {
     dispatch(getPlayerRecordsOk(playerRecords.getRecordsList(getState(), playerId), playerId));
   } else {
     dispatch(getPlayerRecordsRequest(playerId));
   }
 
-  return fetch(`${API_HOST}${getUrl(playerId, options, url)}`)
+  return fetch(`${API_HOST}${getUrl(playerId, modifiedOptions, url)}`)
     .then(response => response.json())
-    .then(json => Object.keys(json)
-    .map(key => ({
-      name: key,
-      value: json[key][key],
-      hero_id: json[key].hero_id,
-      start_time: json[key].start_time,
-      match_id: json[key].match_id,
-      game_mode: json[key].game_mode,
-    }))
-    .filter(record => Boolean(record.value)))
     .then(json => dispatch(getPlayerRecordsOk(json, playerId)))
     .catch(error => dispatch(getPlayerRecordsError(error, playerId)));
 };

--- a/src/components/Player/Pages/Records/Records.jsx
+++ b/src/components/Player/Pages/Records/Records.jsx
@@ -12,7 +12,8 @@ import dataColumns from 'components/Player/Pages/matchDataColumns';
 import ButtonGarden from 'components/ButtonGarden';
 import playerRecordsColumns from './playerRecordsColumns';
 
-const recordsColumns = dataColumns.filter(col => col !== 'win_rate');
+const excludedColumns = ['win_rate', 'level'];
+const recordsColumns = dataColumns.filter(col => !excludedColumns.includes(col));
 
 const Records = ({ routeParams, data, error, loading, playerId }) => {
   const selected = routeParams.subInfo || recordsColumns[0];

--- a/src/components/Player/Pages/Records/Records.jsx
+++ b/src/components/Player/Pages/Records/Records.jsx
@@ -26,7 +26,14 @@ const Records = ({ routeParams, data, error, loading, playerId }) => {
       selectedButton={selected}
     />
     <Container title={strings.heading_records} error={error} loading={loading}>
-      <Table columns={playerRecordsColumns.concat({ displayName: strings[`th_${selected}`], field: selected })} data={data} />
+      <Table
+        columns={playerRecordsColumns.concat({
+          displayName: strings[`th_${selected}`] || strings.th_record,
+          displayFn: (row, col, field) => (field && field.toFixed ? Number(field.toFixed(2)) : ''),
+          field: selected,
+          relativeBars: true,
+        })} data={data}
+      />
     </Container>
   </div>);
 };

--- a/src/components/Player/Pages/Records/Records.jsx
+++ b/src/components/Player/Pages/Records/Records.jsx
@@ -3,20 +3,35 @@ import { connect } from 'react-redux';
 import {
   getPlayerRecords,
 } from 'actions';
+import { browserHistory } from 'react-router';
 import { playerRecords } from 'reducers';
 import Table from 'components/Table';
 import Container from 'components/Container';
 import strings from 'lang';
+import dataColumns from 'components/Player/Pages/matchDataColumns';
+import ButtonGarden from 'components/ButtonGarden';
 import playerRecordsColumns from './playerRecordsColumns';
 
-const Records = ({ data, error, loading }) => (
-  <Container title={strings.heading_records} error={error} loading={loading}>
-    <Table columns={playerRecordsColumns} data={data} />
-  </Container>
-);
+const recordsColumns = dataColumns.filter(col => col !== 'win_rate');
+
+const Records = ({ routeParams, data, error, loading, playerId }) => {
+  const selected = routeParams.subInfo || recordsColumns[0];
+  return (<div style={{ fontSize: 10 }}>
+    <ButtonGarden
+      onClick={(buttonName) => {
+        browserHistory.push(`/players/${playerId}/records/${buttonName}${window.location.search}`);
+      }}
+      buttonNames={recordsColumns}
+      selectedButton={selected}
+    />
+    <Container title={strings.heading_records} error={error} loading={loading}>
+      <Table columns={playerRecordsColumns.concat({ displayName: strings[`th_${selected}`], field: selected })} data={data} />
+    </Container>
+  </div>);
+};
 
 const getData = (props) => {
-  props.getPlayerRecords(props.playerId, props.location.query);
+  props.getPlayerRecords(props.playerId, props.location.query, props.routeParams.subInfo || recordsColumns[0]);
 };
 
 class RequestLayer extends React.Component {
@@ -42,7 +57,7 @@ const mapStateToProps = (state, { playerId }) => ({
 });
 
 const mapDispatchToProps = dispatch => ({
-  getPlayerRecords: (playerId, options) => dispatch(getPlayerRecords(playerId, options)),
+  getPlayerRecords: (playerId, options, subInfo) => dispatch(getPlayerRecords(playerId, options, subInfo)),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(RequestLayer);

--- a/src/components/Player/Pages/Records/playerRecordsColumns.jsx
+++ b/src/components/Player/Pages/Records/playerRecordsColumns.jsx
@@ -2,14 +2,6 @@ import { transformations } from 'utility';
 import strings from 'lang';
 
 export default [{
-  displayName: strings.th_title,
-  field: 'name',
-  displayFn: (row, col, field) => strings[`heading_${field}`],
-}, {
-  displayName: strings.th_record,
-  field: 'value',
-  sortFn: true,
-}, {
   displayName: strings.th_hero_id,
   tooltip: strings.tooltip_hero_id,
   field: 'hero_id',
@@ -21,4 +13,15 @@ export default [{
   field: 'match_id',
   sortFn: true,
   displayFn: transformations.match_id_and_game_mode,
+}, {
+  displayName: strings.th_result,
+  tooltip: strings.tooltip_result,
+  field: 'radiant_win',
+  displayFn: transformations.radiant_win,
+}, {
+  displayName: strings.th_duration,
+  tooltip: strings.tooltip_duration,
+  field: 'duration',
+  sortFn: true,
+  displayFn: transformations.duration,
 }];

--- a/src/utility/index.jsx
+++ b/src/utility/index.jsx
@@ -252,7 +252,7 @@ export const transformations = {
           {getString(field)}
         </span>
         <span className={subTextStyle.subText} style={{ display: 'block', marginTop: 1 }}>
-          {strings[`skill_${row.skill}`] || strings.general_unknown} {strings.th_skill}
+          {row.skill ? `${strings[`skill_${row.skill}`]} ${strings.th_skill}` : ''}
         </span>
       </div>);
   },


### PR DESCRIPTION
Records page:

* Instead of just returning a single row for each record, this now uses a ButtonGarden selector and returns the top 10 matches for each record.

* This allows users to discover more matches that are high in a particular stat, and helps mitigate issues where a record is affected by a fluky data point.

* Uses the /matches endpoint + sort field, so we could retire the /records endpoint from core.