### PR TITLE
make view on github a button

### DIFF
--- a/src/components/Announce/Announce.jsx
+++ b/src/components/Announce/Announce.jsx
@@ -12,9 +12,17 @@ import styles from './Announce.css';
 const Announce = ({ title, body, onClick, link, location }) => (
   <div className={`${styles.announce} ${location.pathname === '/' ? styles.home : ''}`}>
     <main>
-      <h4><a href={link} title={strings.announce_github_more}><IconGithub /> {title}</a></h4>
+      <h4><IconGithub /> {title}</h4>
       {body && <ReactMarkdown source={body} />}
     </main>
+    <aside>
+      <RaisedButton
+        backgroundColor={styles.blue}
+        href={link}
+        target="_blank"
+        label={strings.announce_github_more}
+      />
+    </aside>
     <aside>
       <RaisedButton
         backgroundColor={styles.blue}

--- a/src/lang/en-US.json
+++ b/src/lang/en-US.json
@@ -16,7 +16,7 @@
   "analysis_expected": "of",
 
   "announce_dismiss": "Dismiss",
-  "announce_github_more": "View more on GitHub",
+  "announce_github_more": "View on GitHub",
 
   "app_name": "OpenDota",
   "app_language": "Language",


### PR DESCRIPTION
I think the current link is too obscure, and making it a separate button might be more useful.

Also made the github link open in a new window.