### PR TITLE
adds proptypes to some components

### DIFF
--- a/src/components/Table/SortedTable/withSort.jsx
+++ b/src/components/Table/SortedTable/withSort.jsx
@@ -23,6 +23,13 @@ export default (Table, id = uuid.v4()) => {
     return <span />;
   };
 
+  SortedTable.propTypes = {
+    data: React.PropTypes.array,
+    sortState: React.PropTypes.string,
+    sortField: React.PropTypes.string,
+    sortTable: React.PropTypes.func,
+  };
+
   const mapStateToProps = (state, { data }) => ({
     sortState: table.getSortState(state, id),
     sortField: table.getSortField(state, id),

--- a/src/components/Table/TableHeader.jsx
+++ b/src/components/Table/TableHeader.jsx
@@ -17,4 +17,12 @@ const TableHeader = ({ columns, sortState, sortField, sortClick, totalWidth }) =
   </MaterialTableRow>
 );
 
+TableHeader.propTypes = {
+  columns: React.PropTypes.array,
+  sortState: React.PropTypes.string,
+  sortField: React.PropTypes.string,
+  sortClick: React.PropTypes.string,
+  totalWidth: React.PropTypes.number,
+};
+
 export default TableHeader;

--- a/src/components/Visualizations/Graph/Graph.jsx
+++ b/src/components/Visualizations/Graph/Graph.jsx
@@ -7,6 +7,11 @@ const Graph = ({ id, height = 320 }) => (
   <div style={{ height }} id={id} />
 );
 
+Graph.propTypes = {
+  id: React.PropTypes.string,
+  height: React.PropTypes.number,
+};
+
 const generateGraph = ({
   columns = [],
   type,
@@ -110,6 +115,9 @@ class GraphWrapper extends Component {
     return <Graph id={this.id} height={this.props.height} />;
   }
 }
+GraphWrapper.propTypes = {
+  height: React.PropTypes.number,
+};
 
 /*
 const { string, number, arrayOf, shape, func, bool } = React.PropTypes;

--- a/src/components/Visualizations/Graph/TrendGraph.jsx
+++ b/src/components/Visualizations/Graph/TrendGraph.jsx
@@ -22,6 +22,9 @@ const TrendGraph = ({ columns, name, tooltip, onClick }) => (
 
 TrendGraph.propTypes = {
   columns: React.PropTypes.arrayOf(),
+  name: React.PropTypes.string,
+  tooltip: React.PropTypes.string,
+  onClick: React.PropTypes.func,
 };
 
 export default TrendGraph;

--- a/src/components/Visualizations/Table/HeroImage.jsx
+++ b/src/components/Visualizations/Table/HeroImage.jsx
@@ -97,7 +97,7 @@ const TableHeroImage = ({
   </div>
 );
 
-const { number, string, oneOfType, bool, node } = React.PropTypes;
+const { number, string, oneOfType, bool, node, object } = React.PropTypes;
 
 TableHeroImage.propTypes = {
   parsed: number,
@@ -112,6 +112,11 @@ TableHeroImage.propTypes = {
   playerSlot: number,
   hideText: bool,
   party: node,
+  confirmed: bool,
+  heroName: string,
+  showPvgnaGuide: bool,
+  pvgnaGuideInfo: object,
+
 };
 
 // If need party or estimated, just add new prop with default val = solo and change icons depending what needs
@@ -126,5 +131,8 @@ export const Mmr = ({ number }) => (
     {number || strings.general_unknown}
   </span>
 );
+Mmr.propTypes = {
+  number: React.PropTypes.number,
+};
 
 export default TableHeroImage;

--- a/src/components/Wordcloud/Wordcloud.jsx
+++ b/src/components/Wordcloud/Wordcloud.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
 import wordcloud from 'wordcloud';
 import uuid from 'uuid';
@@ -85,6 +85,12 @@ class Wordcloud extends React.Component {
 Wordcloud.defaultProps = {
   counts: {},
   height: 600,
+};
+const { string, number } = PropTypes;
+Wordcloud.propTypes = {
+  counts: string,
+  width: number,
+  height: number,
 };
 
 const mapStateToProps = state => ({


### PR DESCRIPTION
Questions:
* We seem to have several different ways of referencing the react proptypes.  Is one recommended?  I mostly used `React.PropTypes.string` but that's kind of scary because if I mistype `React.proptypes.string`, the lint will pass but the component will crash on run when it tries to access a nested nonexistent property.