### PR TITLE
use new /recentMatches endpoint

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -16,6 +16,7 @@ export * from './player/playerWinLossActions';
 export * from './player/playerWardmapActions';
 export * from './player/playerWordcloudActions';
 export * from './player/playerTrendsActions';
+export * from './player/playerRecentMatchesActions';
 export * from './formActions';
 export * from './rankingActions';
 export * from './benchmarkActions';

--- a/src/actions/player/playerMatchesActions.js
+++ b/src/actions/player/playerMatchesActions.js
@@ -1,9 +1,6 @@
 /* global API_HOST */
 import fetch from 'isomorphic-fetch';
 import {
-  playerMatches,
-} from 'reducers';
-import {
   getUrl,
 } from 'actions/utility';
 
@@ -24,11 +21,10 @@ export const getPlayerMatchesRequest = id => ({
   id,
 });
 
-export const getPlayerMatchesOk = (payload, id, maxSize) => ({
+export const getPlayerMatchesOk = (payload, id) => ({
   type: OK,
   payload,
   id,
-  maxSize,
 });
 
 export const getPlayerMatchesError = (payload, id) => ({
@@ -54,23 +50,14 @@ export const defaultPlayerMatchesOptions = {
   ],
 };
 
-export const getPlayerMatches = (playerId, options = {}, getAllData, forceRefresh) => (dispatch, getState) => {
+export const getPlayerMatches = (playerId, options = {}) => (dispatch, getState) => {
   const modifiedOptions = {
     ...defaultPlayerMatchesOptions,
     ...options,
   };
-
-  if (playerMatches.isLoaded(getState(), playerId)) {
-    if (playerMatches.isMaxSize(getState(), playerId) && !forceRefresh) {
-      return dispatch(getPlayerMatchesOk(playerMatches.getMatchList(getState(), playerId), playerId, getAllData));
-    }
-    dispatch(getPlayerMatchesOk(playerMatches.getMatchList(getState(), playerId), playerId, false));
-  } else {
-    dispatch(getPlayerMatchesRequest(playerId));
-  }
-
+  dispatch(getPlayerMatchesRequest(playerId));
   return fetch(`${API_HOST}${getUrl(playerId, modifiedOptions, url)}`)
     .then(response => response.json())
-    .then(json => dispatch(getPlayerMatchesOk(json, playerId, getAllData)))
+    .then(json => dispatch(getPlayerMatchesOk(json, playerId)))
     .catch(error => dispatch(getPlayerMatchesError(error, playerId)));
 };

--- a/src/actions/player/playerMatchesActions.js
+++ b/src/actions/player/playerMatchesActions.js
@@ -50,7 +50,7 @@ export const defaultPlayerMatchesOptions = {
   ],
 };
 
-export const getPlayerMatches = (playerId, options = {}) => (dispatch, getState) => {
+export const getPlayerMatches = (playerId, options = {}) => (dispatch) => {
   const modifiedOptions = {
     ...defaultPlayerMatchesOptions,
     ...options,

--- a/src/actions/player/playerRecentMatchesActions.js
+++ b/src/actions/player/playerRecentMatchesActions.js
@@ -33,7 +33,7 @@ export const getPlayerRecentMatchesError = (payload, id) => ({
   id,
 });
 
-export const getPlayerRecentMatches = (playerId, options = {}) => (dispatch, getState) => {
+export const getPlayerRecentMatches = (playerId, options = {}) => (dispatch) => {
   dispatch(getPlayerRecentMatchesRequest(playerId));
   return fetch(`${API_HOST}${getUrl(playerId, options, url)}`)
     .then(response => response.json())

--- a/src/actions/player/playerRecentMatchesActions.js
+++ b/src/actions/player/playerRecentMatchesActions.js
@@ -1,0 +1,42 @@
+/* global API_HOST */
+import fetch from 'isomorphic-fetch';
+import {
+  getUrl,
+} from 'actions/utility';
+
+const url = playerId => `/api/players/${playerId}/recentMatches`;
+
+const REQUEST = 'playerRecentMatches/REQUEST';
+const OK = 'playerRecentMatches/OK';
+const ERROR = 'playerRecentMatches/ERROR';
+
+export const playerRecentMatchesActions = {
+  REQUEST,
+  OK,
+  ERROR,
+};
+
+export const getPlayerRecentMatchesRequest = id => ({
+  type: REQUEST,
+  id,
+});
+
+export const getPlayerRecentMatchesOk = (payload, id) => ({
+  type: OK,
+  payload,
+  id,
+});
+
+export const getPlayerRecentMatchesError = (payload, id) => ({
+  type: ERROR,
+  payload,
+  id,
+});
+
+export const getPlayerRecentMatches = (playerId, options = {}) => (dispatch, getState) => {
+  dispatch(getPlayerRecentMatchesRequest(playerId));
+  return fetch(`${API_HOST}${getUrl(playerId, options, url)}`)
+    .then(response => response.json())
+    .then(json => dispatch(getPlayerRecentMatchesOk(json, playerId)))
+    .catch(error => dispatch(getPlayerRecentMatchesError(error, playerId)));
+};

--- a/src/components/Player/Pages/Overview/Overview.jsx
+++ b/src/components/Player/Pages/Overview/Overview.jsx
@@ -2,13 +2,13 @@ import React from 'react';
 import { connect } from 'react-redux';
 import strings from 'lang';
 import {
-  getPlayerMatches,
+  getPlayerRecentMatches,
   getPlayerHeroes,
   getPlayerPeers,
   getPvgnaHeroGuides,
 } from 'actions';
 import {
-  playerMatches,
+  playerRecentMatches,
   playerHeroes,
   playerPeers,
 } from 'reducers';
@@ -20,7 +20,6 @@ import Container from 'components/Container';
 import playerMatchesColumns from 'components/Player/Pages/Matches/playerMatchesColumns';
 import { playerHeroesOverviewColumns } from 'components/Player/Pages/Heroes/playerHeroesColumns';
 import { playerPeersOverviewColumns } from 'components/Player/Pages/Peers/playerPeersColumns';
-import { defaultPlayerMatchesOptions } from 'actions/player/playerMatchesActions';
 import util from 'util';
 import styles from './Overview.css';
 import sumStyles from './Summary.css';
@@ -94,19 +93,7 @@ const Overview = ({
 );
 
 const getData = (props) => {
-  props.getPlayerMatches(props.playerId, { ...props.location.query,
-    limit: MAX_MATCHES_ROWS,
-    significant: 0,
-    project: defaultPlayerMatchesOptions.project
-      .concat([
-        'xp_per_min',
-        'gold_per_min',
-        'hero_damage',
-        'tower_damage',
-        'hero_healing',
-        'last_hits',
-      ]),
-  });
+  props.getPlayerRecentMatches(props.playerId);
   props.getPlayerHeroes(props.playerId, props.location.query);
   props.getPlayerPeers(props.playerId, props.location.query);
   props.getPvgnaHeroGuides();
@@ -134,9 +121,9 @@ const mergeHeroGuides = (heroes, heroGuides) => heroes.map(hero => ({
 }));
 
 const mapStateToProps = (state, { playerId }) => ({
-  matchesData: playerMatches.getMatchList(state, playerId),
-  matchesLoading: playerMatches.getLoading(state, playerId),
-  matchesError: playerMatches.getError(state, playerId),
+  matchesData: playerRecentMatches.getMatchList(state, playerId),
+  matchesLoading: playerRecentMatches.getLoading(state, playerId),
+  matchesError: playerRecentMatches.getError(state, playerId),
   heroesData: mergeHeroGuides(playerHeroes.getHeroList(state, playerId), getPvgnaGuides(state)),
   heroesLoading: playerHeroes.getLoading(state, playerId),
   heroesError: playerHeroes.getError(state, playerId),
@@ -146,7 +133,7 @@ const mapStateToProps = (state, { playerId }) => ({
 });
 
 const mapDispatchToProps = dispatch => ({
-  getPlayerMatches: (playerId, options) => dispatch(getPlayerMatches(playerId, options)),
+  getPlayerRecentMatches: (playerId, options) => dispatch(getPlayerRecentMatches(playerId, options)),
   getPlayerHeroes: (playerId, options) => dispatch(getPlayerHeroes(playerId, options)),
   getPlayerPeers: (playerId, options) => dispatch(getPlayerPeers(playerId, options)),
   getPvgnaHeroGuides: () => dispatch(getPvgnaHeroGuides()),

--- a/src/reducers/gotPlayer/index.js
+++ b/src/reducers/gotPlayer/index.js
@@ -14,6 +14,7 @@ import items, { getPlayerItems } from 'reducers/gotPlayer/items';
 import wardmap, { getPlayerWardmap } from 'reducers/gotPlayer/wardmap';
 import wordcloud, { getPlayerWordcloud } from 'reducers/gotPlayer/wordcloud';
 import trends, { getPlayerTrends } from 'reducers/gotPlayer/trends';
+import recentMatches, { getPlayerRecentMatches } from 'reducers/gotPlayer/recentMatches';
 
 export default combineReducers({
   playerReducer,
@@ -31,6 +32,7 @@ export default combineReducers({
   wardmap,
   wordcloud,
   trends,
+  recentMatches,
 });
 
 const player = {
@@ -53,4 +55,5 @@ export {
   getPlayerWardmap as playerWardmap,
   getPlayerWordcloud as playerWordcloud,
   getPlayerTrends as playerTrends,
+  getPlayerRecentMatches as playerRecentMatches,
 };

--- a/src/reducers/gotPlayer/recentMatches.js
+++ b/src/reducers/gotPlayer/recentMatches.js
@@ -1,0 +1,19 @@
+import { playerRecentMatchesActions } from 'actions';
+import createReducer from 'reducers/reducerFactory';
+
+const initialState = {
+  loading: true,
+  error: false,
+  loaded: false,
+  list: [],
+};
+
+export default createReducer(initialState, playerRecentMatchesActions);
+
+export const getPlayerRecentMatches = {
+  getPlayerRecentMatchesById: (state, id) => state.app.gotPlayer.recentMatches.byId[id] || { ...initialState },
+  getError: (state, id) => getPlayerRecentMatches.getPlayerRecentMatchesById(state, id).error,
+  getLoading: (state, id) => getPlayerRecentMatches.getPlayerRecentMatchesById(state, id).loading,
+  isLoaded: (state, id) => getPlayerRecentMatches.getPlayerRecentMatchesById(state, id).loaded,
+  getMatchList: (state, id) => getPlayerRecentMatches.getPlayerRecentMatchesById(state, id).list,
+};

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -23,6 +23,7 @@ import gotPlayer, {
   playerWardmap,
   playerWordcloud,
   playerTrends,
+  playerRecentMatches,
 } from 'reducers/gotPlayer';
 import form, { getForm } from 'reducers/form';
 import request from 'reducers/request';
@@ -50,6 +51,7 @@ export {
   playerWardmap,
   playerWordcloud,
   playerTrends,
+  playerRecentMatches,
   getProPlayers as proPlayers,
   getProMatches as proMatches,
   getForm as form,


### PR DESCRIPTION
fixes #862 

Uses the new endpoint to load just 20 matches server side.

Load times reduced to around 120ms from 500ms.