### PR TITLE
Add lane information on match row, fix text cutoff

### DIFF
--- a/src/actions/player/playerMatchesActions.js
+++ b/src/actions/player/playerMatchesActions.js
@@ -47,6 +47,8 @@ export const defaultPlayerMatchesOptions = {
     'deaths',
     'assists',
     'skill',
+    'lane_role',
+    'is_roaming',
   ],
 };
 

--- a/src/components/Visualizations/Table/HeroImage.css
+++ b/src/components/Visualizations/Table/HeroImage.css
@@ -5,7 +5,7 @@
   flex-direction: column;
   justify-content: center;
   line-height: 1.2;
-  width: 120px;
+  width: 125px;
   text-align: left;
 
   & > span {

--- a/src/utility/index.jsx
+++ b/src/utility/index.jsx
@@ -196,9 +196,10 @@ export const percentile = (pct) => {
 
 const getSubtitle = (row) => {
   if (row.match_id && row.player_slot !== undefined) {
-    return (isRadiant(row.player_slot) ? strings.general_radiant : strings.general_dire) + 
-           (row.is_roaming ? ' / ' + strings.roaming : (row.lane_role ? ' / ' + strings[`lane_role_${row.lane_role}`] : ''));
-  } else if (row.last_played) { 
+    let laneName;
+    if (row.is_roaming) { laneName = ` / ${strings.roaming}`; } else { laneName = row.lane_role ? ` / ${strings[`lane_role_${row.lane_role}`]}` : ''; }
+    return (isRadiant(row.player_slot) ? strings.general_radiant : strings.general_dire) + laneName;
+  } else if (row.last_played) {
     return <FromNowTooltip timestamp={row.last_played} />;
   } else if (row.start_time) {
     return <FromNowTooltip timestamp={row.start_time} />;

--- a/src/utility/index.jsx
+++ b/src/utility/index.jsx
@@ -196,8 +196,9 @@ export const percentile = (pct) => {
 
 const getSubtitle = (row) => {
   if (row.match_id && row.player_slot !== undefined) {
-    return isRadiant(row.player_slot) ? strings.general_radiant : strings.general_dire;
-  } else if (row.last_played) {
+    return (isRadiant(row.player_slot) ? strings.general_radiant : strings.general_dire) + 
+           (row.is_roaming ? ' / ' + strings.roaming : (row.lane_role ? ' / ' + strings[`lane_role_${row.lane_role}`] : ''));
+  } else if (row.last_played) { 
     return <FromNowTooltip timestamp={row.last_played} />;
   } else if (row.start_time) {
     return <FromNowTooltip timestamp={row.start_time} />;


### PR DESCRIPTION
Add text showing which lane a hero was in, or indicate they were roaming,
to match rows in tables on Overview and Matches player pages.
Additionally, the ">" next to the hero name was getting cut off by
the parent container when the hero was Legion Commander, so widen
the container slightly.

Resolves #406 