### PR TITLE
Add Timeline component to graphs tab

### DIFF
--- a/src/components/Match/matchPages.jsx
+++ b/src/components/Match/matchPages.jsx
@@ -3,6 +3,7 @@ import strings from 'lang';
 import Heading from 'components/Heading';
 import Table from 'components/Table';
 import TeamfightMap from 'components/Match/TeamfightMap';
+import Timeline from 'components/Match/Overview/Timeline';
 import Vision from './Vision';
 import CastTable from './CastTable';
 import CrossTable from './CrossTable';
@@ -118,6 +119,7 @@ const matchPages = [Overview, {
   key: 'graphs',
   parsed: true,
   content: match => (<div>
+    <Timeline match={match} />
     <MatchGraph match={match} type="difference" />
     <MatchGraph match={match} type="gold" />
     <MatchGraph match={match} type="xp" />


### PR DESCRIPTION
@howardchung are there any additional changes that you had in mind for this? For example, it could be useful to have the Timeline component sticky to the top of the page as the user scrolls down.

![Graphs tab with the Timeline component included above graphs](https://cloud.githubusercontent.com/assets/1341869/26599189/b91fafea-4545-11e7-97e5-af0ee5aa7b64.png)

Resolves #978 