### PR TITLE
Add Networth Indicators to Story

### DIFF
--- a/src/components/Match/Match.css
+++ b/src/components/Match/Match.css
@@ -249,6 +249,25 @@
   height: 20px;
 }
 
+.storyNetWorthBar {
+  display: flex;
+}
+
+.storyNetWorthBar > div {
+  display: inline-block;
+  height: 7px;
+}
+
+.storyNetWorthBar > div:first-child {
+  border-bottom-left-radius: 3px;
+  border-top-left-radius: 3px;
+}
+
+.storyNetWorthBar > div:last-child {
+  border-bottom-right-radius: 3px;
+  border-top-right-radius: 3px;
+}
+
 .logFilterForm {
   max-width: 600px;
   display: flex;

--- a/src/components/Match/Match.css
+++ b/src/components/Match/Match.css
@@ -268,6 +268,20 @@
   border-top-right-radius: 3px;
 }
 
+.storyNetWorthText {
+  display: flex;
+  text-align: center;
+}
+
+.storyNetWorthText > div {
+  display: inline-block;
+}
+
+.storyNetWorthText > div:nth-child(2) {
+  position: absolute;
+  transform: translateX(-50%);
+}
+
 .logFilterForm {
   max-width: 600px;
   display: flex;

--- a/src/components/Match/MatchStory.jsx
+++ b/src/components/Match/MatchStory.jsx
@@ -29,7 +29,7 @@ const GoldSpan = amount => (
       height="17px"
       role="presentation"
       src={`${API_HOST}/apps/dota2/images/tooltips/gold.png`}
-      style={{ marginLeft: 3 }}
+      style={{ marginLeft: '3px' }}
     />
   </span>
 );

--- a/src/components/Match/MatchStory.jsx
+++ b/src/components/Match/MatchStory.jsx
@@ -569,7 +569,10 @@ class TimeMarkerEvent extends StoryEvent {
           {GoldSpan(this.radiant_gold)}
         </div>
         <div style={{ color: this.radiant_gold > this.dire_gold ? styles.green : styles.red, left: `${this.radiant_percent}%` }}>
-          {Math.abs(this.radiant_percent - this.dire_percent)}% / {GoldSpan(Math.abs(this.radiant_gold - this.dire_gold))} Diff
+          {formatTemplate(strings.story_networth_diff, {
+            percent: Math.abs(this.radiant_percent - this.dire_percent),
+            gold: GoldSpan(Math.abs(this.radiant_gold - this.dire_gold)),
+          })}
         </div>
         <div style={{ width: `${this.dire_percent}%` }}>
           {GoldSpan(this.dire_gold)}

--- a/src/components/Match/MatchStory.jsx
+++ b/src/components/Match/MatchStory.jsx
@@ -23,12 +23,13 @@ const TEAM = {
 
 const GoldSpan = amount => (
   <span key={`gold_${amount}`} className={styles.storySpan}>
-    <font color={styles.golden}>{amount} </font>
+    <font color={styles.golden}>{amount.toLocaleString()}</font>
     <img
       width="25px"
       height="17px"
       role="presentation"
       src={`${API_HOST}/apps/dota2/images/tooltips/gold.png`}
+      style={{ marginLeft: 3 }}
     />
   </span>
 );
@@ -560,9 +561,20 @@ class TimeMarkerEvent extends StoryEvent {
   }
   format() {
     return [
-      <h3 key={`minute_${this.minutes}_subheading`}>
+      <h3 key={`minute_${this.minutes}_subheading`} style={{ marginBottom: 0 }}>
         {formatTemplate(strings.story_time_marker, { minutes: this.minutes })}
       </h3>,
+      <div key={`minute_${this.minutes}_networth_text`} className={styles.storyNetWorthText}>
+        <div style={{ width: `${this.radiant_percent}%` }}>
+          {GoldSpan(this.radiant_gold)}
+        </div>
+        <div style={{ left: `${this.radiant_percent}%` }}>
+          {Math.abs(this.radiant_percent - this.dire_percent)}% / {GoldSpan(Math.abs(this.radiant_gold - this.dire_gold))} Diff
+        </div>
+        <div style={{ width: `${this.dire_percent}%` }}>
+          {GoldSpan(this.dire_gold)}
+        </div>
+      </div>,
       <div key={`minute_${this.minutes}_networth`} className={styles.storyNetWorthBar}>
         <div style={{ backgroundColor: styles.green, width: `${this.radiant_percent}%` }}></div>
         <div style={{ backgroundColor: styles.red, width: `${this.dire_percent}%` }}></div>

--- a/src/components/Match/MatchStory.jsx
+++ b/src/components/Match/MatchStory.jsx
@@ -597,7 +597,6 @@ class GameoverEvent extends StoryEvent {
       .reduce((a, b) => a + b, 0);
   }
   format() {
-    console.log(`score: ${this.radiant_score}`);
     return formatTemplate(strings.story_gameover, {
       duration: formatSeconds(this.time),
       winning_team: TeamSpan(this.winning_team),

--- a/src/components/Match/MatchStory.jsx
+++ b/src/components/Match/MatchStory.jsx
@@ -589,11 +589,11 @@ class GameoverEvent extends StoryEvent {
     this.winning_team = match.radiant_win;
     this.radiant_score = match.radiant_score || match.players
       .filter(player => player.isRadiant)
-      .map(player => player["kills"])
+      .map(player => player.kills)
       .reduce((a, b) => a + b, 0);
     this.dire_score = match.dire_score || match.players
       .filter(player => !player.isRadiant)
-      .map(player => player["kills"])
+      .map(player => player.kills)
       .reduce((a, b) => a + b, 0);
   }
   format() {

--- a/src/components/Match/MatchStory.jsx
+++ b/src/components/Match/MatchStory.jsx
@@ -576,9 +576,9 @@ class TimeMarkerEvent extends StoryEvent {
         </div>
       </div>,
       <div key={`minute_${this.minutes}_networth`} className={styles.storyNetWorthBar}>
-        <div style={{ backgroundColor: styles.green, width: `${this.radiant_percent}%` }}></div>
-        <div style={{ backgroundColor: styles.red, width: `${this.dire_percent}%` }}></div>
-      </div>
+        <div style={{ backgroundColor: styles.green, width: `${this.radiant_percent}%` }} />
+        <div style={{ backgroundColor: styles.red, width: `${this.dire_percent}%` }} />
+      </div>,
     ];
   }
 }

--- a/src/components/Match/MatchStory.jsx
+++ b/src/components/Match/MatchStory.jsx
@@ -545,11 +545,11 @@ class TimeMarkerEvent extends StoryEvent {
     this.radiant_gold = match.players
       .filter(player => player.isRadiant)
       .map(player => player.gold_t[minutes])
-      .reduce((a, b) => a + b);
+      .reduce((a, b) => a + b, 0);
     this.dire_gold = match.players
       .filter(player => !player.isRadiant)
       .map(player => player.gold_t[minutes])
-      .reduce((a, b) => a + b);
+      .reduce((a, b) => a + b, 0);
     this.radiant_percent = Math.round(100 * this.radiant_gold / (this.radiant_gold + this.dire_gold));
     this.dire_percent = 100 - this.radiant_percent;
   }
@@ -587,10 +587,17 @@ class GameoverEvent extends StoryEvent {
   constructor(match) {
     super(match.duration);
     this.winning_team = match.radiant_win;
-    this.radiant_score = match.radiant_score;
-    this.dire_score = match.dire_score;
+    this.radiant_score = match.radiant_score || match.players
+      .filter(player => player.isRadiant)
+      .map(player => player["kills"])
+      .reduce((a, b) => a + b, 0);
+    this.dire_score = match.dire_score || match.players
+      .filter(player => !player.isRadiant)
+      .map(player => player["kills"])
+      .reduce((a, b) => a + b, 0);
   }
   format() {
+    console.log(`score: ${this.radiant_score}`);
     return formatTemplate(strings.story_gameover, {
       duration: formatSeconds(this.time),
       winning_team: TeamSpan(this.winning_team),

--- a/src/components/Match/MatchStory.jsx
+++ b/src/components/Match/MatchStory.jsx
@@ -568,7 +568,7 @@ class TimeMarkerEvent extends StoryEvent {
         <div style={{ width: `${this.radiant_percent}%` }}>
           {GoldSpan(this.radiant_gold)}
         </div>
-        <div style={{ left: `${this.radiant_percent}%` }}>
+        <div style={{ color: this.radiant_gold > this.dire_gold ? styles.green : styles.red, left: `${this.radiant_percent}%` }}>
           {Math.abs(this.radiant_percent - this.dire_percent)}% / {GoldSpan(Math.abs(this.radiant_gold - this.dire_gold))} Diff
         </div>
         <div style={{ width: `${this.dire_percent}%` }}>

--- a/src/lang/en-US.json
+++ b/src/lang/en-US.json
@@ -561,6 +561,7 @@
   "story_item_purchase": "{player} purchased a {item} at {time}",
   "story_predicted_victory": "{players} predicted {team} would win",
   "story_predicted_victory_empty": "No one",
+  "story_networth_diff": "{percent}% / {gold} Diff",
 
   "tab_overview": "Overview",
   "tab_matches": "Matches",


### PR DESCRIPTION
Adds a networth indicator to each time marker in the story tab.

Suggestions welcome. I feel like there is a better way to show the text here.

fixes #1065

Example:
![image](https://user-images.githubusercontent.com/3231343/28495690-36325a06-6f0c-11e7-9053-58a4dab852e6.png)
