### PR TITLE
Made player wardmap responsive to screen size (#390)

### DIFF
--- a/src/components/Player/Pages/Wardmap/Wardmap.jsx
+++ b/src/components/Player/Pages/Wardmap/Wardmap.jsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { connect } from 'react-redux';
+import { calculateResponsiveState } from 'redux-responsive';
 import { getPlayerWardmap } from 'actions';
 import Heatmap from 'components/Heatmap';
 import Container from 'components/Container';
 import strings from 'lang';
 import { unpackPositionData } from 'utility';
 import styles from './Wardmap.css';
-import { calculateResponsiveState } from 'redux-responsive';
 
 const getData = (props) => {
   props.getPlayerWardmap(props.playerId, props.location.search);
@@ -18,14 +18,14 @@ class RequestLayer extends React.Component {
     window.addEventListener('resize', this.props.updateWindowSize);
   }
 
-  componentWillUnmount() {
-    window.removeEventListener('resize', this.props.updateWindowSize);
-  }
-
   componentWillUpdate(nextProps) {
     if (this.props.playerId !== nextProps.playerId || this.props.location.key !== nextProps.location.key) {
       getData(nextProps);
     }
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('resize', this.props.updateWindowSize);
   }
 
   render() {

--- a/src/components/Player/Pages/Wardmap/Wardmap.jsx
+++ b/src/components/Player/Pages/Wardmap/Wardmap.jsx
@@ -6,6 +6,7 @@ import Container from 'components/Container';
 import strings from 'lang';
 import { unpackPositionData } from 'utility';
 import styles from './Wardmap.css';
+import { calculateResponsiveState } from 'redux-responsive';
 
 const getData = (props) => {
   props.getPlayerWardmap(props.playerId, props.location.search);
@@ -14,6 +15,11 @@ const getData = (props) => {
 class RequestLayer extends React.Component {
   componentWillMount() {
     getData(this.props);
+    window.addEventListener('resize', this.props.updateWindowSize);
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('resize', this.props.updateWindowSize);
   }
 
   componentWillUpdate(nextProps) {
@@ -23,7 +29,9 @@ class RequestLayer extends React.Component {
   }
 
   render() {
-    const { error, loading, data } = this.props;
+    const { error, loading, data, browser } = this.props;
+    const heatmapWidth = browser.width - 50;
+
     return (
       <div className={styles.wardmaps}>
         <Container
@@ -32,7 +40,10 @@ class RequestLayer extends React.Component {
           error={error}
           loading={loading}
         >
-          <Heatmap points={unpackPositionData(data.obs)} />
+          <Heatmap
+            points={unpackPositionData(data.obs)}
+            width={heatmapWidth > 1440 ? 1440 : heatmapWidth}
+          />
         </Container>
         <Container
           title={strings.th_ward_sentry}
@@ -40,7 +51,10 @@ class RequestLayer extends React.Component {
           error={error}
           loading={loading}
         >
-          <Heatmap points={unpackPositionData(data.sen)} />
+          <Heatmap
+            points={unpackPositionData(data.sen)}
+            width={heatmapWidth > 1440 ? 1440 : heatmapWidth}
+          />
         </Container>
       </div>
     );
@@ -51,10 +65,12 @@ const mapStateToProps = state => ({
   data: state.app.playerWardmap.data,
   loading: state.app.playerWardmap.loading,
   error: state.app.playerWardmap.data.error,
+  browser: state.browser,
 });
 
 const mapDispatchToProps = dispatch => ({
   getPlayerWardmap: (playerId, options) => dispatch(getPlayerWardmap(playerId, options)),
+  updateWindowSize: () => dispatch(calculateResponsiveState(window)),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(RequestLayer);

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -6,7 +6,6 @@ import {
 } from 'redux';
 import thunkMiddleware from 'redux-thunk';
 import {
-  responsiveStateReducer,
   createResponsiveStoreEnhancer,
   createResponsiveStateReducer,
 } from 'redux-responsive';
@@ -17,7 +16,7 @@ const reducer = combineReducers({
   browser: createResponsiveStateReducer(null, {
     extraFields: () => ({
       width: window.innerWidth,
-    })
+    }),
   }),
 });
 /* eslint-disable no-underscore-dangle */
@@ -30,5 +29,5 @@ export default createStore(
   composeEnhancers(
     createResponsiveStoreEnhancer(),
     applyMiddleware(thunkMiddleware),
-  )
+  ),
 );

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -8,12 +8,17 @@ import thunkMiddleware from 'redux-thunk';
 import {
   responsiveStateReducer,
   createResponsiveStoreEnhancer,
+  createResponsiveStateReducer,
 } from 'redux-responsive';
 import app from 'reducers';
 
 const reducer = combineReducers({
   app,
-  browser: responsiveStateReducer,
+  browser: createResponsiveStateReducer(null, {
+    extraFields: () => ({
+      width: window.innerWidth,
+    })
+  }),
 });
 /* eslint-disable no-underscore-dangle */
 // This enables the redux dev tools extension, or does nothing if not installed
@@ -25,4 +30,5 @@ export default createStore(
   composeEnhancers(
     createResponsiveStoreEnhancer(),
     applyMiddleware(thunkMiddleware),
-  ));
+  )
+);


### PR DESCRIPTION
fixes #390 

I added an extra field for the redux-responsive and started the window listener in the actual component itself (not sure if you wanted it watching the whole time).

Padding is 25 on either side so width - 50 and maxed to 1440.

Screens:

![fireshot capture 13 - zomby - wardmap - opendota -_ - http___localhost_8080_players_58052218_wardmap](https://user-images.githubusercontent.com/25160789/28825181-d5828efc-768a-11e7-8c82-4a5a08f42d95.png)

![fireshot capture 14 - zomby - wardmap - opendota -_ - http___localhost_8080_players_58052218_wardmap](https://user-images.githubusercontent.com/25160789/28825191-dbdbaef0-768a-11e7-86b0-2832f9babedc.png)

![fireshot capture 12 - zomby - wardmap - opendota -_ - http___localhost_8080_players_58052218_wardmap](https://user-images.githubusercontent.com/25160789/28825251-1031826a-768b-11e7-8211-6896e5df5474.jpg)

