### PR TITLE
Static Order for Tooltips in XP/Gold Graph

### DIFF
--- a/src/components/Match/MatchGraph.jsx
+++ b/src/components/Match/MatchGraph.jsx
@@ -49,8 +49,11 @@ const drawGraphs = (props, id) => {
       },
       tooltip: {
         contents(d, defaultTitleFormat, defaultValueFormat, color) {
-          d.sort((a, b) => b.value - a.value);
           return this.getTooltipContent(d, defaultTitleFormat, valueFormat || defaultValueFormat, color);
+        },
+        order: (a, b) => {
+          if (a.id === 'Gold' || b.id === 'Gold') return a.id - b.id;
+          return b.value - a.value;
         },
       },
     });

--- a/src/components/Match/MatchGraph.jsx
+++ b/src/components/Match/MatchGraph.jsx
@@ -52,7 +52,7 @@ const drawGraphs = (props, id) => {
           return this.getTooltipContent(d, defaultTitleFormat, valueFormat || defaultValueFormat, color);
         },
         order: (a, b) => {
-          if (a.id === 'Gold' || b.id === 'Gold') return a.id - b.id;
+          if (props.type === 'difference') return a.id - b.id;
           return b.value - a.value;
         },
       },


### PR DESCRIPTION
fixes #1078 

https://github.com/odota/ui/issues/1078

C3 has an internal tooltip order function that gets run unless defined via the order key. I'm open to suggestions on how to identify if it's a gold/xp graph since the function is in a closure without access to the `drawGraphs` `props` argument. For now, I think it's an ideal solution for something like this.