### PR TITLE
Linked overview page table headers to corresponding tabs

### DIFF
--- a/src/components/Container/index.jsx
+++ b/src/components/Container/index.jsx
@@ -22,9 +22,9 @@ AsyncContainer.propTypes = {
   children: node,
 };
 
-const Container = ({ title, subtitle, style, className, children, error, loading, hide }) => (!hide ? (
+const Container = ({ title, subtitle, style, className, children, error, loading, hide, titleTo }) => (!hide ? (
   <div className={className} style={{ ...style }}>
-    {title && <Heading title={title} subtitle={subtitle} />}
+    {title && <Heading title={title} subtitle={subtitle} titleTo={titleTo} />}
     <AsyncContainer error={error} loading={loading}>
       {children}
     </AsyncContainer>

--- a/src/components/Heading/Heading.css
+++ b/src/components/Heading/Heading.css
@@ -13,6 +13,15 @@
     fill: var(--textColorPrimary);
   }
 
+  & a {
+    color: var(--primaryTextColor);
+    text-decoration: none;
+
+    &:hover {
+      color: var(--primaryLinkColor);
+    }
+  }
+
   & .title {
     font-size: 20px;
   }

--- a/src/components/Heading/Heading.jsx
+++ b/src/components/Heading/Heading.jsx
@@ -1,13 +1,18 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { Link } from 'react-router-dom';
 import ActionLabelOutline from 'material-ui/svg-icons/action/label-outline';
 import styles from './Heading.css';
 
-const Heading = ({ title = '', icon = <ActionLabelOutline />, subtitle, className }) => (
+const Heading = ({ title = '', titleTo, icon = <ActionLabelOutline />, subtitle, className }) => (
   <div className={`${styles.tableHeading} ${className}`}>
     {icon}
     <span className={styles.title}>
-      {title.trim()}
+      {titleTo ?
+        <Link to={titleTo}>
+          {title.trim()}
+        </Link>
+        : title.trim()}
     </span>
     <span className={styles.subtitle}>
       {subtitle}

--- a/src/components/Player/Pages/Overview/Overview.jsx
+++ b/src/components/Player/Pages/Overview/Overview.jsx
@@ -36,6 +36,7 @@ const Overview = ({
   <div className={styles.overviewContainer}>
     <Container
       title={strings.heading_avg_and_max}
+      titleTo={`/players/${playerId}/records`}
       subtitle={util.format(strings.subheading_avg_and_max, MAX_MATCHES_ROWS)}
       className={sumStyles.summaryContainer}
       loading={matchesLoading}
@@ -45,6 +46,7 @@ const Overview = ({
     </Container>
     <Container
       title={strings.heading_matches}
+      titleTo={`/players/${playerId}/matches`}
       className={styles.matchesContainer}
       loading={matchesLoading}
       error={matchesError}
@@ -58,6 +60,7 @@ const Overview = ({
     <div className={styles.heroesContainer}>
       <Container
         title={strings.heading_peers}
+        titleTo={`/players/${playerId}/peers`}
         loading={peersLoading}
         error={peersError}
       >
@@ -69,6 +72,7 @@ const Overview = ({
       </Container>
       <Container
         title={strings.heading_heroes}
+        titleTo={`/players/${playerId}/heroes`}
         loading={heroesLoading}
         error={heroesError}
       >


### PR DESCRIPTION
fixes #1106 

Added a titleTo prop into the Container - which passes into Header - which then renders the link if need be.

(The header is blue as my mouse hovered over it)
![image](https://user-images.githubusercontent.com/25160789/29496296-2c71e8d4-8595-11e7-993f-0abe49b8b306.png)
