### PR TITLE
Moved Ability Build to its own table

### DIFF
--- a/src/components/Match/AbilityBuildTable.jsx
+++ b/src/components/Match/AbilityBuildTable.jsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { isRadiant, getTeamName } from 'utility';
+import { IconRadiant, IconDire } from 'components/Icons';
+import Heading from 'components/Heading';
+import Table from 'components/Table';
+import styles from './Match.css';
+
+const filterMatchPlayers = (players, team = '') =>
+  players
+    .filter(player => (team === 'radiant' && isRadiant(player.player_slot)) || (team === 'dire' && !isRadiant(player.player_slot)) || team === '')
+    .sort((a, b) => a.player_slot - b.player_slot);
+
+const standardizeLevel = (skilledAt, obj) => {
+  // Invoker (74) is different than everyone else
+  if (obj.hero_id !== 74) {
+    if (skilledAt === 16) {
+      return 17;
+    } else if (skilledAt === 17) {
+      return 19;
+    } else if (skilledAt === 18) {
+      return 24;
+    }
+  }
+  return skilledAt;
+};
+
+const convertArrayToKeys = (obj, fieldName = '') => ({
+  ...obj,
+  ...obj[fieldName].reduce(
+    (acc, cur, index) => ({
+      ...acc,
+      [`ability_upgrades_arr_${standardizeLevel(index, obj) + 1}`]: cur,
+    }),
+    {},
+  ),
+});
+
+export default ({ players = [], columns, heading = '', radiantTeam = {}, direTeam = {}, summable = false }) => {
+  const keyedPlayers = players.map(player => convertArrayToKeys(player, 'ability_upgrades_arr'));
+  return (
+    <div>
+      <Heading title={`${getTeamName(radiantTeam, true)} - ${heading}`} icon={<IconRadiant className={styles.iconRadiant} />} />
+      <Table data={filterMatchPlayers(keyedPlayers, 'radiant')} columns={columns} summable={summable} />
+      <Heading title={`${getTeamName(direTeam, false)} - ${heading}`} icon={<IconDire className={styles.iconDire} />} />
+      <Table data={filterMatchPlayers(keyedPlayers, 'dire')} columns={columns} summable={summable} />
+    </div>
+  );
+};

--- a/src/components/Match/Match.css
+++ b/src/components/Match/Match.css
@@ -17,7 +17,7 @@
   & .ability {
     position: relative;
     display: inline-block;
-    margin: 0 2px;
+    /*margin: 0 2px;*/
 
     &:first-of-type {
       margin-left: 0;
@@ -41,14 +41,18 @@
       left: 0;
       font-size: 10px;
     }
+
+    & .placeholder {
+      background-color: transparent;
+    }
   }
 
   /* React-tooltip ability upgrades */
   & > div {
     pointer-events: auto !important;
-    margin-left: 3px !important;
+    /*margin-left: 3px !important;
     margin-top: 1px !important;
-    padding: 6px 12px 2px !important;
+    /*padding: 6px 12px 2px !important;*/
 
     &:hover {
       visibility: visible !important;

--- a/src/components/Match/Match.css
+++ b/src/components/Match/Match.css
@@ -14,10 +14,11 @@
 }
 
 .abilityUpgrades {
+  margin: -8px;
+
   & .ability {
     position: relative;
     display: inline-block;
-    /*margin: 0 2px;*/
 
     &:first-of-type {
       margin-left: 0;
@@ -28,14 +29,14 @@
     }
 
     & img {
-      height: 34px;
-      width: 34px;
+      height: 30px;
+      width: 30px;
     }
 
     & > div {
       background-color: var(--darkPrimaryColor);
-      height: 34px;
-      width: 34px;
+      height: 30px;
+      width: 30px;
       text-align: center;
       bottom: 0;
       left: 0;

--- a/src/components/Match/Overview/Overview.jsx
+++ b/src/components/Match/Overview/Overview.jsx
@@ -2,7 +2,8 @@ import React from 'react';
 import strings from 'lang';
 
 import TeamTable from '../TeamTable';
-import { overviewColumns } from '../matchColumns';
+import AbilityBuildTable from '../AbilityBuildTable';
+import { overviewColumns, abilityColumns } from '../matchColumns';
 import BuildingMap from '../BuildingMap';
 import MatchGraph from '../MatchGraph';
 import styles from './Overview.css';
@@ -22,6 +23,13 @@ export default {
         radiantTeam={match.radiant_team}
         direTeam={match.dire_team}
         summable
+      />
+      <AbilityBuildTable
+        players={match.players}
+        columns={abilityColumns()}
+        heading={'Ability Build'}
+        radiantTeam={match.radiant_team}
+        direTeam={match.dire_team}
       />
       <div className={styles.overviewMapGraph}>
         <div className={`${styles.map} ${!match.version && styles.centeredMap}`}>

--- a/src/components/Match/matchColumns.jsx
+++ b/src/components/Match/matchColumns.jsx
@@ -11,20 +11,10 @@ import heroNames from 'dotaconstants/build/hero_names.json';
 import buffs from 'dotaconstants/build/permanent_buffs.json';
 import util from 'util';
 import strings from 'lang';
-import {
-  formatSeconds,
-  abbreviateNumber,
-  transformations,
-  percentile,
-  sum,
-} from 'utility';
-import {
-  TableHeroImage,
-  inflictorWithValue,
-} from 'components/Visualizations';
+import { formatSeconds, abbreviateNumber, transformations, percentile, sum } from 'utility';
+import { TableHeroImage, inflictorWithValue } from 'components/Visualizations';
 import ReactTooltip from 'react-tooltip';
 import { RadioButton } from 'material-ui/RadioButton';
-import NavigationMoreHoriz from 'material-ui/svg-icons/navigation/more-horiz';
 import ActionOpenInNew from 'material-ui/svg-icons/action/open-in-new';
 import { Mmr } from 'components/Visualizations/Table/HeroImage';
 import { IconBackpack } from 'components/Icons';
@@ -49,8 +39,7 @@ export const heroTd = (row, col, field, index, hideName, party, showPvgnaGuide =
     repicked={row.repicked}
     predictedVictory={row.pred_vict}
     leaverStatus={row.leaver_status}
-  />
-  );
+  />);
 
 export const heroTdColumn = {
   displayName: strings.th_avatar,
@@ -101,205 +90,217 @@ const findBuyTime = (purchaseLog, itemKey, _itemSkipCount) => {
 };
 
 export const overviewColumns = (match) => {
-  const cols = [{
-    displayName: strings.th_avatar,
-    field: 'player_slot',
-    displayFn: (row, col, field, i) => heroTd(row, col, field, i, false, parties(row, match), true),
-    sortFn: true,
-  }, {
-    displayName: strings.th_level,
-    tooltip: strings.tooltip_level,
-    field: 'level',
-    sortFn: true,
-    maxFn: true,
-    sumFn: true,
-  }, {
-    displayName: strings.th_kills,
-    tooltip: strings.tooltip_kills,
-    field: 'kills',
-    sortFn: true,
-    displayFn: transformations.kda,
-    sumFn: true,
-  }, {
-    displayName: strings.th_deaths,
-    tooltip: strings.tooltip_deaths,
-    field: 'deaths',
-    sortFn: true,
-    sumFn: true,
-  }, {
-    displayName: strings.th_assists,
-    tooltip: strings.tooltip_assists,
-    field: 'assists',
-    sortFn: true,
-    sumFn: true,
-  }, {
-    displayName: strings.th_gold_per_min,
-    tooltip: strings.tooltip_gold_per_min,
-    field: 'gold_per_min',
-    sortFn: true,
-    color: styles.golden,
-    sumFn: true,
-    relativeBars: true,
-  }, {
-    displayName: strings.th_xp_per_min,
-    tooltip: strings.tooltip_xp_per_min,
-    field: 'xp_per_min',
-    sortFn: true,
-    sumFn: true,
-    relativeBars: true,
-  }, {
-    displayName: strings.th_last_hits,
-    tooltip: strings.tooltip_last_hits,
-    field: 'last_hits',
-    sortFn: true,
-    sumFn: true,
-    relativeBars: true,
-  }, {
-    displayName: strings.th_denies,
-    tooltip: strings.tooltip_denies,
-    field: 'denies',
-    sortFn: true,
-    sumFn: true,
-    relativeBars: true,
-  }, {
-    displayName: strings.th_hero_damage,
-    tooltip: strings.tooltip_hero_damage,
-    field: 'hero_damage',
-    sortFn: true,
-    sumFn: true,
-    displayFn: row => abbreviateNumber(row.hero_damage),
-    relativeBars: true,
-  }, {
-    displayName: strings.th_hero_healing,
-    tooltip: strings.tooltip_hero_healing,
-    field: 'hero_healing',
-    sortFn: true,
-    sumFn: true,
-    displayFn: row => abbreviateNumber(row.hero_healing),
-    relativeBars: true,
-  }, {
-    displayName: strings.th_tower_damage,
-    tooltip: strings.tooltip_tower_damage,
-    field: 'tower_damage',
-    displayFn: row => abbreviateNumber(row.tower_damage),
-    sortFn: true,
-    sumFn: true,
-    relativeBars: true,
-  }, {
-    displayName: (
-      <span className={styles.thGold}>
-        <img src={`${API_HOST}/apps/dota2/images/tooltips/gold.png`} role="presentation" />
-        {strings.th_gold}
-      </span>
-    ),
-    tooltip: strings.tooltip_gold,
-    field: 'total_gold',
-    sortFn: true,
-    color: styles.golden,
-    sumFn: true,
-    displayFn: row => abbreviateNumber(row.total_gold),
-    relativeBars: true,
-  }, {
-    displayName: strings.th_items,
-    tooltip: strings.tooltip_items,
-    field: 'items',
-    displayFn: (row) => {
-      const itemArray = [];
-      const additionalItemArray = [];
-      const backpackItemArray = [];
-
-      const visitedItemsCount = {};
-
-      for (let i = 0; i < 6; i += 1) {
-        const itemKey = itemIds[row[`item_${i}`]];
-        const { itemSkipCount, purchaseEvent } = findBuyTime(row.purchase_log, itemKey, visitedItemsCount[itemKey]);
-        visitedItemsCount[itemKey] = itemSkipCount;
-
-        if (items[itemKey]) {
-          itemArray.push(inflictorWithValue(itemKey, formatSeconds(purchaseEvent && purchaseEvent.time)));
-        }
-
-        // Use hero_id because Meepo showing up as an additional unit in some matches http://dev.dota2.com/showthread.php?t=132401
-        if (row.hero_id === 80 && row.additional_units) {
-          const additionalItemKey = itemIds[row.additional_units[0][`item_${i}`]];
-          const additionalFirstPurchase = row.first_purchase_time && row.first_purchase_time[additionalItemKey];
-
-          if (items[additionalItemKey]) {
-            additionalItemArray.push(inflictorWithValue(additionalItemKey, formatSeconds(additionalFirstPurchase)));
-          }
-        }
-
-        const backpackItemKey = itemIds[row[`backpack_${i}`]];
-        const backpackfirstPurchase = row.first_purchase_time && row.first_purchase_time[backpackItemKey];
-
-        if (items[backpackItemKey]) {
-          backpackItemArray.push(inflictorWithValue(backpackItemKey, formatSeconds(backpackfirstPurchase)));
-        }
-      }
-
-      return (
-        <div className={styles.items}>
-          {itemArray && <div>{itemArray}</div>}
-          {additionalItemArray && <div>{additionalItemArray}</div>}
-          {backpackItemArray && backpackItemArray.length > 0 &&
-            <div className={styles.backpack}>
-              <div
-                data-hint={strings.tooltip_backpack}
-                data-hint-position="bottom"
-              ><IconBackpack /></div>
-              {backpackItemArray}
-            </div>
-          }
-        </div>
-      );
+  const cols = [
+    {
+      displayName: strings.th_avatar,
+      field: 'player_slot',
+      displayFn: (row, col, field, i) => heroTd(row, col, field, i, false, parties(row, match), true),
+      sortFn: true,
     },
-  }]
-    .concat(
-      match.players.map(player => player.permanent_buffs && player.permanent_buffs.length).reduce(sum, 0) > 0 ? {
+    {
+      displayName: strings.th_level,
+      tooltip: strings.tooltip_level,
+      field: 'level',
+      sortFn: true,
+      maxFn: true,
+      sumFn: true,
+    },
+    {
+      displayName: strings.th_kills,
+      tooltip: strings.tooltip_kills,
+      field: 'kills',
+      sortFn: true,
+      displayFn: transformations.kda,
+      sumFn: true,
+    },
+    {
+      displayName: strings.th_deaths,
+      tooltip: strings.tooltip_deaths,
+      field: 'deaths',
+      sortFn: true,
+      sumFn: true,
+    },
+    {
+      displayName: strings.th_assists,
+      tooltip: strings.tooltip_assists,
+      field: 'assists',
+      sortFn: true,
+      sumFn: true,
+    },
+    {
+      displayName: strings.th_gold_per_min,
+      tooltip: strings.tooltip_gold_per_min,
+      field: 'gold_per_min',
+      sortFn: true,
+      color: styles.golden,
+      sumFn: true,
+      relativeBars: true,
+    },
+    {
+      displayName: strings.th_xp_per_min,
+      tooltip: strings.tooltip_xp_per_min,
+      field: 'xp_per_min',
+      sortFn: true,
+      sumFn: true,
+      relativeBars: true,
+    },
+    {
+      displayName: strings.th_last_hits,
+      tooltip: strings.tooltip_last_hits,
+      field: 'last_hits',
+      sortFn: true,
+      sumFn: true,
+      relativeBars: true,
+    },
+    {
+      displayName: strings.th_denies,
+      tooltip: strings.tooltip_denies,
+      field: 'denies',
+      sortFn: true,
+      sumFn: true,
+      relativeBars: true,
+    },
+    {
+      displayName: strings.th_hero_damage,
+      tooltip: strings.tooltip_hero_damage,
+      field: 'hero_damage',
+      sortFn: true,
+      sumFn: true,
+      displayFn: row => abbreviateNumber(row.hero_damage),
+      relativeBars: true,
+    },
+    {
+      displayName: strings.th_hero_healing,
+      tooltip: strings.tooltip_hero_healing,
+      field: 'hero_healing',
+      sortFn: true,
+      sumFn: true,
+      displayFn: row => abbreviateNumber(row.hero_healing),
+      relativeBars: true,
+    },
+    {
+      displayName: strings.th_tower_damage,
+      tooltip: strings.tooltip_tower_damage,
+      field: 'tower_damage',
+      displayFn: row => abbreviateNumber(row.tower_damage),
+      sortFn: true,
+      sumFn: true,
+      relativeBars: true,
+    },
+    {
+      displayName: (
+        <span className={styles.thGold}>
+          <img src={`${API_HOST}/apps/dota2/images/tooltips/gold.png`} role="presentation" />
+          {strings.th_gold}
+        </span>
+      ),
+      tooltip: strings.tooltip_gold,
+      field: 'total_gold',
+      sortFn: true,
+      color: styles.golden,
+      sumFn: true,
+      displayFn: row => abbreviateNumber(row.total_gold),
+      relativeBars: true,
+    },
+    {
+      displayName: strings.th_items,
+      tooltip: strings.tooltip_items,
+      field: 'items',
+      displayFn: (row) => {
+        const itemArray = [];
+        const additionalItemArray = [];
+        const backpackItemArray = [];
+
+        const visitedItemsCount = {};
+
+        for (let i = 0; i < 6; i += 1) {
+          const itemKey = itemIds[row[`item_${i}`]];
+          const { itemSkipCount, purchaseEvent } = findBuyTime(row.purchase_log, itemKey, visitedItemsCount[itemKey]);
+          visitedItemsCount[itemKey] = itemSkipCount;
+
+          if (items[itemKey]) {
+            itemArray.push(inflictorWithValue(itemKey, formatSeconds(purchaseEvent && purchaseEvent.time)));
+          }
+
+          // Use hero_id because Meepo showing up as an additional unit in some matches http://dev.dota2.com/showthread.php?t=132401
+          if (row.hero_id === 80 && row.additional_units) {
+            const additionalItemKey = itemIds[row.additional_units[0][`item_${i}`]];
+            const additionalFirstPurchase = row.first_purchase_time && row.first_purchase_time[additionalItemKey];
+
+            if (items[additionalItemKey]) {
+              additionalItemArray.push(inflictorWithValue(additionalItemKey, formatSeconds(additionalFirstPurchase)));
+            }
+          }
+
+          const backpackItemKey = itemIds[row[`backpack_${i}`]];
+          const backpackfirstPurchase = row.first_purchase_time && row.first_purchase_time[backpackItemKey];
+
+          if (items[backpackItemKey]) {
+            backpackItemArray.push(inflictorWithValue(backpackItemKey, formatSeconds(backpackfirstPurchase)));
+          }
+        }
+
+        return (
+          <div className={styles.items}>
+            {itemArray &&
+              <div>
+                {itemArray}
+              </div>}
+            {additionalItemArray &&
+              <div>
+                {additionalItemArray}
+              </div>}
+            {backpackItemArray &&
+              backpackItemArray.length > 0 &&
+              <div className={styles.backpack}>
+                <div data-hint={strings.tooltip_backpack} data-hint-position="bottom">
+                  <IconBackpack />
+                </div>
+                {backpackItemArray}
+              </div>}
+          </div>
+        );
+      },
+    },
+  ].concat(
+    match.players.map(player => player.permanent_buffs && player.permanent_buffs.length).reduce(sum, 0) > 0
+      ? {
         displayName: strings.th_permanent_buffs,
         field: 'permanent_buffs',
-        displayFn: row => (
-          row.permanent_buffs && row.permanent_buffs.length > 0
-            ? row.permanent_buffs.map(buff => inflictorWithValue(buffs[buff.permanent_buff], buff.stack_count, 'buff'))
-            : '-'
-        ),
-      } : [],
-    )
-    .concat({
-      displayName: (
-        <div style={{ marginLeft: 10 }}>
-          {strings.th_ability_builds}
+        displayFn: row =>
+          (row.permanent_buffs && row.permanent_buffs.length > 0 ? row.permanent_buffs.map(buff => inflictorWithValue(buffs[buff.permanent_buff], buff.stack_count, 'buff')) : '-'),
+      }
+      : [],
+  );
+
+  return cols;
+};
+
+export const abilityColumns = () => {
+  const cols = Array.from(new Array(26), (_, index) => ({
+    displayName: `${index}`,
+    tooltip: 'Ability upgraded at this level',
+    field: `ability_upgrades_arr_${index}`,
+    displayFn: row =>
+      (<div data-tip data-for={`au_${row.player_slot}`} className={styles.abilityUpgrades}>
+        <div className={styles.ability}>
+          {inflictorWithValue(abilityIds[row[`ability_upgrades_arr_${index}`]]) || <div className={styles.placeholder} />}
         </div>
-      ),
-      tooltip: strings.tooltip_ability_builds,
-      displayFn: row => (
-        <div data-tip data-for={`au_${row.player_slot}`} className={styles.abilityUpgrades}>
-          {row.ability_upgrades_arr ? <NavigationMoreHoriz /> : <NavigationMoreHoriz style={{ opacity: 0.4 }} />}
-          <ReactTooltip id={`au_${row.player_slot}`} place="left" effect="solid">
-            {row.ability_upgrades_arr ? row.ability_upgrades_arr.map(
-              (ab) => {
-                if (ab && abilityIds[ab]) {
-                  return (
-                    <div className={styles.ability}>
-                      {inflictorWithValue(abilityIds[ab])}
-                    </div>
-                  );
-                }
-                return null;
-              },
-            ) : <div style={{ paddingBottom: 5 }}>{strings.tooltip_ability_builds_expired}</div>}
-          </ReactTooltip>
-        </div>
-      ),
-    });
+      </div>),
+  }));
+
+  cols[0] = {
+    displayName: strings.th_avatar,
+    field: 'player_slot',
+    displayFn: (row, col, field, i) => heroTd(row, col, field, i, false, null, true),
+    sortFn: true,
+  };
 
   return cols;
 };
 
 export const benchmarksColumns = (match) => {
-  const cols = [
-    heroTdColumn,
-  ];
+  const cols = [heroTdColumn];
   if (match.players && match.players[0] && match.players[0].benchmarks) {
     Object.keys(match.players[0].benchmarks).forEach((key, i) => {
       cols.push({
@@ -313,13 +314,17 @@ export const benchmarksColumns = (match) => {
             const bucket = percentile(bm.pct);
             const percent = Number(bm.pct * 100).toFixed(2);
             const value = Number((bm.raw || 0).toFixed(2));
-            return (<div data-tip data-for={`benchmarks_${row.player_slot}_${key}`}>
-              <span style={{ color: styles[bucket.color] }}>{`${percent}%`}</span>
-              <small style={{ margin: '3px' }}>{value}</small>
-              <ReactTooltip id={`benchmarks_${row.player_slot}_${key}`} place="top" effect="solid">
-                {util.format(strings.benchmarks_description, value, strings[`th_${key}`], percent)}
-              </ReactTooltip>
-            </div>);
+            return (
+              <div data-tip data-for={`benchmarks_${row.player_slot}_${key}`}>
+                <span style={{ color: styles[bucket.color] }}>{`${percent}%`}</span>
+                <small style={{ margin: '3px' }}>
+                  {value}
+                </small>
+                <ReactTooltip id={`benchmarks_${row.player_slot}_${key}`} place="top" effect="solid">
+                  {util.format(strings.benchmarks_description, value, strings[`th_${key}`], percent)}
+                </ReactTooltip>
+              </div>
+            );
           }
           return null;
         },
@@ -332,38 +337,133 @@ export const benchmarksColumns = (match) => {
 const displayFantasyComponent = transform => (row, col, field) => {
   const score = Number(transform(field).toFixed(2));
   const raw = Number((field || 0).toFixed(2));
-  return (<div data-tip data-for={`fantasy_${row.player_slot}_${col.field}`}>
-    <span>{score}</span>
-    <small style={{ margin: '3px', color: 'rgb(179, 179, 179)' }}>{raw}</small>
-    <ReactTooltip id={`fantasy_${row.player_slot}_${col.field}`} place="top" effect="solid">
-      {util.format(strings.fantasy_description, raw, score)}
-    </ReactTooltip>
-  </div>);
+  return (
+    <div data-tip data-for={`fantasy_${row.player_slot}_${col.field}`}>
+      <span>
+        {score}
+      </span>
+      <small style={{ margin: '3px', color: 'rgb(179, 179, 179)' }}>
+        {raw}
+      </small>
+      <ReactTooltip id={`fantasy_${row.player_slot}_${col.field}`} place="top" effect="solid">
+        {util.format(strings.fantasy_description, raw, score)}
+      </ReactTooltip>
+    </div>
+  );
 };
 
 const fantasyComponents = [
-  { displayName: strings.th_kills, field: 'kills', fantasyFn: v => 0.3 * v, get displayFn() { return displayFantasyComponent(this.fantasyFn); } },
-  { displayName: strings.th_deaths, field: 'deaths', fantasyFn: v => 3 - (0.3 * v), get displayFn() { return displayFantasyComponent(this.fantasyFn); } },
-  { displayName: strings.th_last_hits, field: 'last_hits', fantasyFn: v => 0.003 * v, get displayFn() { return displayFantasyComponent(this.fantasyFn); } },
-  { displayName: strings.th_denies, field: 'denies', fantasyFn: v => 0.003 * v, get displayFn() { return displayFantasyComponent(this.fantasyFn); } },
-  { displayName: strings.th_gold_per_min, field: 'gold_per_min', fantasyFn: v => 0.002 * v, get displayFn() { return displayFantasyComponent(this.fantasyFn); } },
-  { displayName: strings.th_towers, field: 'towers_killed', fantasyFn: v => 1 * v, get displayFn() { return displayFantasyComponent(this.fantasyFn); } },
-  { displayName: strings.th_roshan, field: 'roshans_killed', fantasyFn: v => 1 * v, get displayFn() { return displayFantasyComponent(this.fantasyFn); } },
-  { displayName: strings.th_teamfight_participation, field: 'teamfight_participation', fantasyFn: v => 3 * v, get displayFn() { return displayFantasyComponent(this.fantasyFn); } },
-  { displayName: strings.th_observers_placed, field: 'obs_placed', fantasyFn: v => 0.5 * v, get displayFn() { return displayFantasyComponent(this.fantasyFn); } },
-  { displayName: strings.th_camps_stacked, field: 'camps_stacked', fantasyFn: v => 0.5 * v, get displayFn() { return displayFantasyComponent(this.fantasyFn); } },
-  { displayName: strings.heading_runes, field: 'rune_pickups', fantasyFn: v => 0.25 * v, get displayFn() { return displayFantasyComponent(this.fantasyFn); } },
-  { displayName: strings.th_firstblood_claimed, field: 'firstblood_claimed', fantasyFn: v => 4 * v, get displayFn() { return displayFantasyComponent(this.fantasyFn); } },
-  { displayName: strings.th_stuns, field: 'stuns', fantasyFn: v => 0.05 * v, get displayFn() { return displayFantasyComponent(this.fantasyFn); } },
+  {
+    displayName: strings.th_kills,
+    field: 'kills',
+    fantasyFn: v => 0.3 * v,
+    get displayFn() {
+      return displayFantasyComponent(this.fantasyFn);
+    },
+  },
+  {
+    displayName: strings.th_deaths,
+    field: 'deaths',
+    fantasyFn: v => 3 - (0.3 * v),
+    get displayFn() {
+      return displayFantasyComponent(this.fantasyFn);
+    },
+  },
+  {
+    displayName: strings.th_last_hits,
+    field: 'last_hits',
+    fantasyFn: v => 0.003 * v,
+    get displayFn() {
+      return displayFantasyComponent(this.fantasyFn);
+    },
+  },
+  {
+    displayName: strings.th_denies,
+    field: 'denies',
+    fantasyFn: v => 0.003 * v,
+    get displayFn() {
+      return displayFantasyComponent(this.fantasyFn);
+    },
+  },
+  {
+    displayName: strings.th_gold_per_min,
+    field: 'gold_per_min',
+    fantasyFn: v => 0.002 * v,
+    get displayFn() {
+      return displayFantasyComponent(this.fantasyFn);
+    },
+  },
+  {
+    displayName: strings.th_towers,
+    field: 'towers_killed',
+    fantasyFn: v => 1 * v,
+    get displayFn() {
+      return displayFantasyComponent(this.fantasyFn);
+    },
+  },
+  {
+    displayName: strings.th_roshan,
+    field: 'roshans_killed',
+    fantasyFn: v => 1 * v,
+    get displayFn() {
+      return displayFantasyComponent(this.fantasyFn);
+    },
+  },
+  {
+    displayName: strings.th_teamfight_participation,
+    field: 'teamfight_participation',
+    fantasyFn: v => 3 * v,
+    get displayFn() {
+      return displayFantasyComponent(this.fantasyFn);
+    },
+  },
+  {
+    displayName: strings.th_observers_placed,
+    field: 'obs_placed',
+    fantasyFn: v => 0.5 * v,
+    get displayFn() {
+      return displayFantasyComponent(this.fantasyFn);
+    },
+  },
+  {
+    displayName: strings.th_camps_stacked,
+    field: 'camps_stacked',
+    fantasyFn: v => 0.5 * v,
+    get displayFn() {
+      return displayFantasyComponent(this.fantasyFn);
+    },
+  },
+  {
+    displayName: strings.heading_runes,
+    field: 'rune_pickups',
+    fantasyFn: v => 0.25 * v,
+    get displayFn() {
+      return displayFantasyComponent(this.fantasyFn);
+    },
+  },
+  {
+    displayName: strings.th_firstblood_claimed,
+    field: 'firstblood_claimed',
+    fantasyFn: v => 4 * v,
+    get displayFn() {
+      return displayFantasyComponent(this.fantasyFn);
+    },
+  },
+  {
+    displayName: strings.th_stuns,
+    field: 'stuns',
+    fantasyFn: v => 0.05 * v,
+    get displayFn() {
+      return displayFantasyComponent(this.fantasyFn);
+    },
+  },
 ];
 
 export const fantasyColumns = [
   heroTdColumn,
-  { displayName: strings.th_fantasy_points,
-    displayFn: row => fantasyComponents
-      .map(comp => comp.fantasyFn(row[comp.field]))
-      .reduce((a, b) => a + b)
-      .toFixed(2),
+  {
+    displayName: strings.th_fantasy_points,
+    displayFn: row => fantasyComponents.map(comp => comp.fantasyFn(row[comp.field])).reduce((a, b) => a + b).toFixed(2),
   },
 ].concat(fantasyComponents);
 
@@ -375,26 +475,29 @@ export const purchaseTimesColumns = (match) => {
     cols.push({
       displayName: `${curTime / 60}'`,
       field: 'purchase_log',
-      displayFn: (row, column, field) => (<div>
-        {field ? field
-          .filter(purchase => (purchase.time >= curTime - bucket && purchase.time < curTime))
-          .sort((p1, p2) => {
-            const item1 = items[p1.key];
-            const item2 = items[p2.key];
-            if (item1 && item2 && p1.time === p2.time) {
-            // We're only concerned with sorting by value
-            // if items are bought at the same time, time is presorted
-              return item1.cost - item2.cost;
-            }
-            return 0;
-          })
-          .map((purchase) => {
-            if (items[purchase.key]) {
-              return inflictorWithValue(purchase.key, formatSeconds(purchase.time));
-            }
-            return null;
-          }) : ''}
-      </div>),
+      displayFn: (row, column, field) =>
+        (<div>
+          {field
+            ? field
+              .filter(purchase => purchase.time >= curTime - bucket && purchase.time < curTime)
+              .sort((p1, p2) => {
+                const item1 = items[p1.key];
+                const item2 = items[p2.key];
+                if (item1 && item2 && p1.time === p2.time) {
+                  // We're only concerned with sorting by value
+                  // if items are bought at the same time, time is presorted
+                  return item1.cost - item2.cost;
+                }
+                return 0;
+              })
+              .map((purchase) => {
+                if (items[purchase.key]) {
+                  return inflictorWithValue(purchase.key, formatSeconds(purchase.time));
+                }
+                return null;
+              })
+            : ''}
+        </div>),
     });
   }
   return cols;
@@ -409,8 +512,8 @@ export const lastHitsTimesColumns = (match) => {
     cols.push({
       displayName: `${minutes}'`,
       field: i,
-      sortFn: row => (row.lh_t && row.lh_t[minutes]),
-      displayFn: row => (`${row.lh_t[minutes]} (+${row.lh_t[minutes] - row.lh_t[minutes - (bucket / 60)]})`),
+      sortFn: row => row.lh_t && row.lh_t[minutes],
+      displayFn: row => `${row.lh_t[minutes]} (+${row.lh_t[minutes] - row.lh_t[minutes - (bucket / 60)]})`,
       relativeBars: true,
     });
   }
@@ -418,7 +521,8 @@ export const lastHitsTimesColumns = (match) => {
 };
 
 export const performanceColumns = [
-  heroTdColumn, {
+  heroTdColumn,
+  {
     displayName: strings.th_multikill,
     tooltip: strings.tooltip_multikill,
     field: 'multi_kills_max',
@@ -426,7 +530,8 @@ export const performanceColumns = [
     displayFn: (row, col, field) => field || '-',
     relativeBars: true,
     sumFn: true,
-  }, {
+  },
+  {
     displayName: strings.th_killstreak,
     tooltip: strings.tooltip_killstreak,
     field: 'kill_streaks_max',
@@ -434,7 +539,8 @@ export const performanceColumns = [
     displayFn: (row, col, field) => field || '-',
     relativeBars: true,
     sumFn: true,
-  }, {
+  },
+  {
     displayName: strings.th_stuns,
     tooltip: strings.tooltip_stuns,
     field: 'stuns',
@@ -442,7 +548,8 @@ export const performanceColumns = [
     displayFn: (row, col, field) => (field ? field.toFixed(2) : '-'),
     relativeBars: true,
     sumFn: true,
-  }, {
+  },
+  {
     displayName: strings.th_stacked,
     tooltip: strings.tooltip_camps_stacked,
     field: 'camps_stacked',
@@ -450,7 +557,8 @@ export const performanceColumns = [
     displayFn: (row, col, field) => field || '-',
     relativeBars: true,
     sumFn: true,
-  }, {
+  },
+  {
     displayName: strings.th_dead,
     tooltip: strings.tooltip_dead,
     field: 'life_state_dead',
@@ -458,7 +566,8 @@ export const performanceColumns = [
     displayFn: (row, col, field) => formatSeconds(field) || '-',
     relativeBars: true,
     sumFn: true,
-  }, {
+  },
+  {
     displayName: strings.th_buybacks,
     tooltip: strings.tooltip_buybacks,
     field: 'buybacks',
@@ -466,7 +575,8 @@ export const performanceColumns = [
     displayFn: (row, col, field) => field || '-',
     relativeBars: true,
     sumFn: true,
-  }, {
+  },
+  {
     displayName: strings.th_pings,
     tooltip: strings.tooltip_pings,
     field: 'pings',
@@ -474,7 +584,8 @@ export const performanceColumns = [
     displayFn: (row, col, field) => field || '-',
     relativeBars: true,
     sumFn: true,
-  }, {
+  },
+  {
     displayName: strings.th_biggest_hit,
     tooltip: strings.tooltip_biggest_hit,
     field: 'max_hero_hit',
@@ -482,14 +593,17 @@ export const performanceColumns = [
     displayFn: (row, column, field) => {
       if (field) {
         const hero = heroNames[field.key] || {};
-        return (<div>
-          {inflictorWithValue(field.inflictor, abbreviateNumber(field.value))}
-          <img src={`${API_HOST}${hero.img}`} className={styles.imgSmall} role="presentation" />
-        </div>);
+        return (
+          <div>
+            {inflictorWithValue(field.inflictor, abbreviateNumber(field.value))}
+            <img src={`${API_HOST}${hero.img}`} className={styles.imgSmall} role="presentation" />
+          </div>
+        );
       }
       return <div />;
     },
-  }, {
+  },
+  {
     displayName: strings.th_other,
     field: 'performance_others',
     sortFn: true,
@@ -497,10 +611,7 @@ export const performanceColumns = [
       const comp = [];
       if (field) {
         if (field.tracked_deaths) {
-          const tooltip = [
-            `${field.tracked_deaths} ${strings.tooltip_others_tracked_deaths}`,
-            `${field.track_gold} ${strings.tooltip_others_track_gold}`,
-          ];
+          const tooltip = [`${field.tracked_deaths} ${strings.tooltip_others_tracked_deaths}`, `${field.track_gold} ${strings.tooltip_others_track_gold}`];
           comp.push(inflictorWithValue('bounty_hunter_track', abbreviateNumber(field.tracked_deaths), '', tooltip.join('\n')));
         }
         if (field.greevils_greed_gold) {
@@ -515,17 +626,25 @@ export const performanceColumns = [
 ];
 
 export const laningColumns = (currentState, setSelectedPlayer) => [
-  { displayFn: (row, col, field, index) => (<RadioButton checked={currentState.selectedPlayer === index} onClick={() => setSelectedPlayer(index)} />) },
-  heroTdColumn, {
+  { displayFn: (row, col, field, index) => <RadioButton checked={currentState.selectedPlayer === index} onClick={() => setSelectedPlayer(index)} /> },
+  heroTdColumn,
+  {
     displayName: strings.th_lane,
     tooltip: strings.tooltip_lane,
     field: 'lane_role',
     sortFn: true,
-    displayFn: (row, col, field) => (<div>
-      <span>{strings[`lane_role_${field}`]}</span>
-      {row.is_roaming && <span className={subtextStyle.subText}>{strings.roaming}</span>}
-    </div>),
-  }, {
+    displayFn: (row, col, field) =>
+      (<div>
+        <span>
+          {strings[`lane_role_${field}`]}
+        </span>
+        {row.is_roaming &&
+          <span className={subtextStyle.subText}>
+            {strings.roaming}
+          </span>}
+      </div>),
+  },
+  {
     displayName: strings.th_lane_efficiency,
     tooltip: strings.tooltip_lane_efficiency,
     field: 'lane_efficiency',
@@ -533,142 +652,150 @@ export const laningColumns = (currentState, setSelectedPlayer) => [
     displayFn: (row, col, field) => (field ? `${(field * 100).toFixed(2)}%` : '-'),
     relativeBars: true,
     sumFn: true,
-  }, {
+  },
+  {
     displayName: strings.th_lhten,
     tooltip: strings.tooltip_lhten,
     field: 'lh_ten',
     sortFn: true,
-    displayFn: (row, col, field) => (field || '-'),
+    displayFn: (row, col, field) => field || '-',
     relativeBars: true,
     sumFn: true,
-  }, {
+  },
+  {
     displayName: strings.th_dnten,
     tooltip: strings.tooltip_dnten,
     field: 'dn_ten',
     sortFn: true,
-    displayFn: (row, col, field) => (field || '-'),
+    displayFn: (row, col, field) => field || '-',
     relativeBars: true,
     sumFn: true,
-  }];
+  },
+];
 
 export const unitKillsColumns = [
-  heroTdColumn, {
+  heroTdColumn,
+  {
     displayName: strings.th_heroes,
     tooltip: strings.farm_heroes,
     field: 'hero_kills',
     sortFn: true,
     displayFn: (row, col, field) => field || '-',
     relativeBars: true,
-  }, {
+  },
+  {
     displayName: strings.th_creeps,
     tooltip: strings.farm_creeps,
     field: 'lane_kills',
     sortFn: true,
     displayFn: (row, col, field) => field || '-',
     relativeBars: true,
-  }, {
+  },
+  {
     displayName: strings.th_neutrals,
     tooltip: strings.farm_neutrals,
     field: 'neutral_kills',
     sortFn: true,
     displayFn: (row, col, field) => field || '-',
     relativeBars: true,
-  }, {
+  },
+  {
     displayName: strings.th_ancients,
     tooltip: strings.farm_ancients,
     field: 'ancient_kills',
     sortFn: true,
     displayFn: (row, col, field) => field || '-',
     relativeBars: true,
-  }, {
+  },
+  {
     displayName: strings.th_towers,
     tooltip: strings.farm_towers,
     field: 'tower_kills',
     sortFn: true,
     displayFn: (row, col, field) => field || '-',
     relativeBars: true,
-  }, {
+  },
+  {
     displayName: strings.th_couriers,
     tooltip: strings.farm_couriers,
     field: 'courier_kills',
     sortFn: true,
     displayFn: (row, col, field) => field || '-',
     relativeBars: true,
-  }, {
+  },
+  {
     displayName: strings.th_roshan,
     tooltip: strings.farm_roshan,
     field: 'roshan_kills',
     sortFn: true,
     displayFn: (row, col, field) => field || '-',
     relativeBars: true,
-  }, {
+  },
+  {
     displayName: strings.th_observers_placed,
     tooltip: strings.farm_observers,
     field: 'observer_kills',
     sortFn: true,
     displayFn: (row, col, field) => field || '-',
     relativeBars: true,
-  }, {
+  },
+  {
     displayName: strings.th_necronomicon,
     tooltip: strings.farm_necronomicon,
     field: 'necronomicon_kills',
     sortFn: true,
     displayFn: (row, col, field) => field || '-',
     relativeBars: true,
-  }, {
+  },
+  {
     displayName: strings.th_other,
     field: 'specific',
     // TODO make this work for non-english (current names are hardcoded in dotaconstants)
-    displayFn: (row, col, field) => (<div>
-      {Object.keys(field || {}).map((unit, index) => (<div key={index}>{`${field[unit]} ${unit}`}</div>))}
-    </div>),
+    displayFn: (row, col, field) =>
+      (<div>
+        {Object.keys(field || {}).map((unit, index) => <div key={index}>{`${field[unit]} ${unit}`}</div>)}
+      </div>),
   },
 ];
 
-export const actionsColumns = [heroTdColumn, {
-  displayName: strings.th_actions_per_min,
-  tooltip: strings.tooltip_actions_per_min,
-  field: 'actions_per_min',
-  sortFn: true,
-  relativeBars: true,
-}]
-  .concat(Object.keys(orderTypes).filter(orderType => `th_${orderTypes[orderType]}` in strings).map(orderType => ({
+export const actionsColumns = [
+  heroTdColumn,
+  {
+    displayName: strings.th_actions_per_min,
+    tooltip: strings.tooltip_actions_per_min,
+    field: 'actions_per_min',
+    sortFn: true,
+    relativeBars: true,
+  },
+].concat(
+  Object.keys(orderTypes).filter(orderType => `th_${orderTypes[orderType]}` in strings).map(orderType => ({
     displayName: strings[`th_${orderTypes[orderType]}`],
     tooltip: strings[`tooltip_${orderTypes[orderType]}`],
     field: orderType,
     sortFn: row => (row.actions ? row.actions[orderType] : 0),
     displayFn: (row, column, value) => value || '-',
     relativeBars: true,
-  })));
+  })),
+);
 
-export const runesColumns = [heroTdColumn]
-  .concat(Object.keys(strings)
-    .filter(str => str.indexOf('rune_') === 0)
-    .map(str => str.split('_')[1])
-    .map(runeType => ({
-      displayName: (
-        <div
-          className={styles.runes}
-          data-tip
-          data-for={`rune_${runeType}`}
-        >
-          <img
-            src={`/assets/images/dota2/runes/${runeType}.png`}
-            role="presentation"
-          />
-          <ReactTooltip id={`rune_${runeType}`} effect="solid">
-            <span>
-              {strings[`rune_${runeType}`]}
-            </span>
-          </ReactTooltip>
-        </div>
-      ),
-      field: `rune_${runeType}`,
-      displayFn: (row, col, value) => (value || '-'),
-      sortFn: row => row.runes && row.runes[runeType],
-      relativeBars: true,
-    })));
-
+export const runesColumns = [heroTdColumn].concat(
+  Object.keys(strings).filter(str => str.indexOf('rune_') === 0).map(str => str.split('_')[1]).map(runeType => ({
+    displayName: (
+      <div className={styles.runes} data-tip data-for={`rune_${runeType}`}>
+        <img src={`/assets/images/dota2/runes/${runeType}.png`} role="presentation" />
+        <ReactTooltip id={`rune_${runeType}`} effect="solid">
+          <span>
+            {strings[`rune_${runeType}`]}
+          </span>
+        </ReactTooltip>
+      </div>
+    ),
+    field: `rune_${runeType}`,
+    displayFn: (row, col, value) => value || '-',
+    sortFn: row => row.runes && row.runes[runeType],
+    relativeBars: true,
+  })),
+);
 
 const cosmeticsRarity = {
   common: '#B0C3D9',
@@ -680,138 +807,139 @@ const cosmeticsRarity = {
   arcana: '#ADE55C',
   ancient: '#EB4B4B',
 };
-export const cosmeticsColumns = [heroTdColumn, {
-  displayName: strings.th_cosmetics,
-  field: 'cosmetics',
-  displayFn: (row, col, field) => field.map((cosmetic, i) => (
-    <div
-      key={i}
-      className={styles.cosmetics}
-      data-tip
-      data-for={`cosmetic_${cosmetic.item_id}`}
-    >
-      <a
-        href={`http://steamcommunity.com/market/listings/570/${cosmetic.name}`}
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        <img
-          src={`${API_HOST}/apps/570/${cosmetic.image_path}`}
-          role="presentation"
-          style={{
-            borderBottom: `2px solid ${cosmetic.item_rarity ? cosmeticsRarity[cosmetic.item_rarity] : styles.gray}`,
-          }}
-        />
-        <ActionOpenInNew />
-      </a>
-      <ReactTooltip id={`cosmetic_${cosmetic.item_id}`} effect="solid">
-        <span style={{ color: cosmetic.item_rarity && cosmeticsRarity[cosmetic.item_rarity] }}>
-          {cosmetic.name}
-          <span>
-            {cosmetic.item_rarity}
-          </span>
-        </span>
-      </ReactTooltip>
-    </div>
-  )),
-}];
+export const cosmeticsColumns = [
+  heroTdColumn,
+  {
+    displayName: strings.th_cosmetics,
+    field: 'cosmetics',
+    displayFn: (row, col, field) =>
+      field.map((cosmetic, i) =>
+        (<div key={i} className={styles.cosmetics} data-tip data-for={`cosmetic_${cosmetic.item_id}`}>
+          <a href={`http://steamcommunity.com/market/listings/570/${cosmetic.name}`} target="_blank" rel="noopener noreferrer">
+            <img
+              src={`${API_HOST}/apps/570/${cosmetic.image_path}`}
+              role="presentation"
+              style={{
+                borderBottom: `2px solid ${cosmetic.item_rarity ? cosmeticsRarity[cosmetic.item_rarity] : styles.gray}`,
+              }}
+            />
+            <ActionOpenInNew />
+          </a>
+          <ReactTooltip id={`cosmetic_${cosmetic.item_id}`} effect="solid">
+            <span style={{ color: cosmetic.item_rarity && cosmeticsRarity[cosmetic.item_rarity] }}>
+              {cosmetic.name}
+              <span>
+                {cosmetic.item_rarity}
+              </span>
+            </span>
+          </ReactTooltip>
+        </div>),
+      ),
+  },
+];
 
+export const goldReasonsColumns = [heroTdColumn].concat(
+  Object.keys(strings).filter(str => str.indexOf('gold_reasons_') === 0).map(gr => ({
+    displayName: strings[gr],
+    field: gr,
+    sortFn: row => (row.gold_reasons ? row.gold_reasons[gr.substring('gold_reasons_'.length)] : 0),
+    displayFn: (row, column, value) => value || '-',
+    relativeBars: true,
+  })),
+);
 
-export const goldReasonsColumns = [heroTdColumn]
-  .concat(Object.keys(strings)
-    .filter(str => str.indexOf('gold_reasons_') === 0)
-    .map(gr => ({
-      displayName: strings[gr],
-      field: gr,
-      sortFn: row => (row.gold_reasons ? row.gold_reasons[gr.substring('gold_reasons_'.length)] : 0),
-      displayFn: (row, column, value) => value || '-',
-      relativeBars: true,
-    })));
+export const xpReasonsColumns = [heroTdColumn].concat(
+  Object.keys(strings).filter(str => str.indexOf('xp_reasons_') === 0).map(xpr => ({
+    displayName: strings[xpr],
+    field: xpr,
+    sortFn: row => (row.xp_reasons ? row.xp_reasons[xpr.substring('xp_reasons_'.length)] : 0),
+    displayFn: (row, column, value) => value || '-',
+    relativeBars: true,
+  })),
+);
 
-export const xpReasonsColumns = [heroTdColumn]
-  .concat(Object.keys(strings)
-    .filter(str => str.indexOf('xp_reasons_') === 0)
-    .map(xpr => ({
-      displayName: strings[xpr],
-      field: xpr,
-      sortFn: row => (row.xp_reasons ? row.xp_reasons[xpr.substring('xp_reasons_'.length)] : 0),
-      displayFn: (row, column, value) => value || '-',
-      relativeBars: true,
-    })));
-
-export const objectiveDamageColumns = [heroTdColumn]
-  .concat(Object.keys(strings).filter(str => str.indexOf('objective_') === 0)
-    .map(obj => ({
-      displayName: strings[obj],
-      field: obj,
-      sortFn: row => (row.objective_damage && row.objective_damage[obj.substring('objective_'.length)]),
-      displayFn: (row, col, value) => value || '-',
-      relativeBars: true,
-    })));
-
+export const objectiveDamageColumns = [heroTdColumn].concat(
+  Object.keys(strings).filter(str => str.indexOf('objective_') === 0).map(obj => ({
+    displayName: strings[obj],
+    field: obj,
+    sortFn: row => row.objective_damage && row.objective_damage[obj.substring('objective_'.length)],
+    displayFn: (row, col, value) => value || '-',
+    relativeBars: true,
+  })),
+);
 
 export const inflictorsColumns = [
-  heroTdColumn, {
+  heroTdColumn,
+  {
     displayName: strings.th_damage_dealt,
     field: 'damage_inflictor',
-    displayFn: (row, col, field) => (field ? Object.keys(field)
-      .sort((a, b) => field[b] - field[a])
-      .map(inflictor => inflictorWithValue(inflictor, abbreviateNumber(field[inflictor]))) : ''),
-  }, {
+    displayFn: (row, col, field) =>
+      (field ? Object.keys(field).sort((a, b) => field[b] - field[a]).map(inflictor => inflictorWithValue(inflictor, abbreviateNumber(field[inflictor]))) : ''),
+  },
+  {
     displayName: strings.th_damage_received,
     field: 'damage_inflictor_received',
-    displayFn: (row, col, field) => (field ? Object.keys(field)
-      .sort((a, b) => field[b] - field[a])
-      .map(inflictor => inflictorWithValue(inflictor, abbreviateNumber(field[inflictor]))) : ''),
+    displayFn: (row, col, field) =>
+      (field ? Object.keys(field).sort((a, b) => field[b] - field[a]).map(inflictor => inflictorWithValue(inflictor, abbreviateNumber(field[inflictor]))) : ''),
   },
 ];
 
 export const castsColumns = [
-  heroTdColumn, {
+  heroTdColumn,
+  {
     displayName: strings.th_abilities,
     tooltip: strings.tooltip_casts,
     field: 'ability_uses',
-    displayFn: (row, col, field) => (field ? Object.keys(field)
-      .sort((a, b) => field[b] - field[a])
-      .map(inflictor => inflictorWithValue(inflictor, abbreviateNumber(field[inflictor]))) : ''),
-  }, {
+    displayFn: (row, col, field) =>
+      (field ? Object.keys(field).sort((a, b) => field[b] - field[a]).map(inflictor => inflictorWithValue(inflictor, abbreviateNumber(field[inflictor]))) : ''),
+  },
+  {
     displayName: strings.th_items,
     tooltip: strings.tooltip_casts,
     field: 'item_uses',
-    displayFn: (row, col, field) => (field ? Object.keys(field)
-      .sort((a, b) => field[b] - field[a])
-      .map(inflictor => inflictorWithValue(inflictor, abbreviateNumber(field[inflictor]))) : ''),
-  }, {
+    displayFn: (row, col, field) =>
+      (field ? Object.keys(field).sort((a, b) => field[b] - field[a]).map(inflictor => inflictorWithValue(inflictor, abbreviateNumber(field[inflictor]))) : ''),
+  },
+  {
     displayName: strings.th_hits,
     tooltip: strings.tooltip_hits,
     field: 'hero_hits',
-    displayFn: (row, col, field) => (field ? Object.keys(field)
-      .sort((a, b) => field[b] - field[a])
-      .map(inflictor => inflictorWithValue(inflictor, abbreviateNumber(field[inflictor]))) : ''),
+    displayFn: (row, col, field) =>
+      (field ? Object.keys(field).sort((a, b) => field[b] - field[a]).map(inflictor => inflictorWithValue(inflictor, abbreviateNumber(field[inflictor]))) : ''),
   },
 ];
 
-export const analysisColumns = [heroTdColumn, {
-  displayName: strings.th_analysis,
-  field: 'analysis',
-  displayFn: (row, col, field) => (
-    Object.keys(field || {}).map((key) => {
-      const val = field[key];
-      val.display = `${val.name}: ${Number(val.value ? val.value.toFixed(2) : '')} / ${Number(val.top.toFixed(2))}`;
-      val.pct = val.score(val.value) / val.score(val.top);
-      if (val.valid) {
-        const percent = field[key].pct;
-        const bucket = percentile(percent);
-        return (<div>
-          <span style={{ color: styles[bucket.color], margin: '10px', fontSize: '18px' }}>{bucket.grade}</span>
-          <span>{field[key].display}</span>
-          <div className={styles.unusedItem}>{ key === 'unused_item' && field[key].metadata.map(item => inflictorWithValue(item)) }</div>
-        </div>);
-      }
-      return null;
-    })
-  ),
-}];
+export const analysisColumns = [
+  heroTdColumn,
+  {
+    displayName: strings.th_analysis,
+    field: 'analysis',
+    displayFn: (row, col, field) =>
+      Object.keys(field || {}).map((key) => {
+        const val = field[key];
+        val.display = `${val.name}: ${Number(val.value ? val.value.toFixed(2) : '')} / ${Number(val.top.toFixed(2))}`;
+        val.pct = val.score(val.value) / val.score(val.top);
+        if (val.valid) {
+          const percent = field[key].pct;
+          const bucket = percentile(percent);
+          return (
+            <div>
+              <span style={{ color: styles[bucket.color], margin: '10px', fontSize: '18px' }}>
+                {bucket.grade}
+              </span>
+              <span>
+                {field[key].display}
+              </span>
+              <div className={styles.unusedItem}>
+                {key === 'unused_item' && field[key].metadata.map(item => inflictorWithValue(item))}
+              </div>
+            </div>
+          );
+        }
+        return null;
+      }),
+  },
+];
 
 const playerDeaths = (row, col, field) => {
   const deaths = [];
@@ -819,15 +947,16 @@ const playerDeaths = (row, col, field) => {
     deaths.push(<img src="/assets/images/player_death.png" role="presentation" />);
   }
   return (
-    field > 0 && <div className={styles.playerDeath}>
+    field > 0 &&
+    <div className={styles.playerDeath}>
       {deaths}
     </div>
   );
 };
 
-const inflictorRow = obj => (row, col, field) => (
-  field ? (
-    <div style={{ maxWidth: '100px' }}>
+const inflictorRow = obj => (row, col, field) =>
+  (field
+    ? <div style={{ maxWidth: '100px' }}>
       {Object.keys(field).map((inflictor) => {
         if (obj[inflictor]) {
           return inflictorWithValue(inflictor, field[inflictor]);
@@ -835,40 +964,46 @@ const inflictorRow = obj => (row, col, field) => (
         return null;
       })}
     </div>
-  ) : ''
-);
+    : '');
 
 export const teamfightColumns = [
-  heroTdColumn, {
+  heroTdColumn,
+  {
     displayName: strings.th_death,
     field: 'deaths',
     sortFn: true,
     displayFn: playerDeaths,
-  }, {
+  },
+  {
     displayName: strings.th_damage,
     field: 'damage',
     sortFn: true,
     relativeBars: true,
-  }, {
+  },
+  {
     displayName: strings.th_healing,
     field: 'healing',
     sortFn: true,
     relativeBars: true,
-  }, {
+  },
+  {
     displayName: strings.th_gold,
     field: 'gold_delta',
     sortFn: true,
     relativeBars: true,
-  }, {
+  },
+  {
     displayName: strings.th_xp,
     field: 'xp_delta',
     sortFn: true,
     relativeBars: true,
-  }, {
+  },
+  {
     displayName: strings.th_abilities,
     field: 'ability_uses',
     displayFn: inflictorRow(abilityKeys),
-  }, {
+  },
+  {
     displayName: strings.th_items,
     field: 'item_uses',
     displayFn: inflictorRow(items),
@@ -962,7 +1097,7 @@ export const visionColumns = [
     ),
     tooltip: strings.tooltip_used_ward_observer,
     field: 'uses_ward_observer',
-    sortFn: row => (row.obs_log && row.obs_log.length),
+    sortFn: row => row.obs_log && row.obs_log.length,
     displayFn: (row, column, value) => value || '-',
     relativeBars: true,
   },
@@ -977,7 +1112,7 @@ export const visionColumns = [
     ),
     tooltip: strings.tooltip_used_ward_sentry,
     field: 'uses_ward_sentry',
-    sortFn: row => (row.sen_log && row.sen_log.length),
+    sortFn: row => row.sen_log && row.sen_log.length,
     displayFn: (row, column, value) => value || '-',
     relativeBars: true,
   },
@@ -992,7 +1127,7 @@ export const visionColumns = [
     ),
     tooltip: strings.tooltip_used_dust,
     field: 'uses_dust',
-    sortFn: row => (row.item_uses && row.item_uses.dust),
+    sortFn: row => row.item_uses && row.item_uses.dust,
     displayFn: (row, column, value) => value || '-',
     relativeBars: true,
   },
@@ -1007,7 +1142,7 @@ export const visionColumns = [
     ),
     tooltip: strings.tooltip_used_smoke_of_deceit,
     field: 'uses_smoke',
-    sortFn: row => (row.item_uses && row.item_uses.smoke_of_deceit),
+    sortFn: row => row.item_uses && row.item_uses.smoke_of_deceit,
     displayFn: (row, column, value) => value || '-',
     relativeBars: true,
   },

--- a/src/components/Match/matchColumns.jsx
+++ b/src/components/Match/matchColumns.jsx
@@ -289,12 +289,7 @@ export const abilityColumns = () => {
       </div>),
   }));
 
-  cols[0] = {
-    displayName: strings.th_avatar,
-    field: 'player_slot',
-    displayFn: (row, col, field, i) => heroTd(row, col, field, i, false, null, true),
-    sortFn: true,
-  };
+  cols[0] = heroTdColumn;
 
   return cols;
 };


### PR DESCRIPTION
I have moved the ability build to its own table per #1131. 

I made a new table called AbilityBuildTable - following standard layout for that.
I then proceeded to map the array from the ability build into keys in order for it to be used by the prop in the Table.

I had to standardize a couple of values due to how they come from the backend.

I'm not sure if this will cause a performance hit or not - if it does I will have to figure something else out.

Picture with dire scrolled to end:
![image](https://user-images.githubusercontent.com/25160789/29648264-dc41f532-8852-11e7-8917-9ca27186be9d.png)
