### PR TITLE
Story improvements

### DIFF
--- a/src/components/Match/MatchStory.jsx
+++ b/src/components/Match/MatchStory.jsx
@@ -114,11 +114,11 @@ const articleFor = (followingWord) => {
   // Whether we use a or an depends on the sound of the following word, but that's much hardder to detect programmatically,
   // so we're looking solely at vowel usage for now.
   if (['A', 'E', 'I', 'O', 'U'].includes(followingWord.charAt(0))) {
-    return strings['article_before_vowel_sound'];
-  } else {
-    return strings['article_before_consonant_sound'];
+    return strings.article_before_vowel_sound;
   }
-}
+
+  return strings.article_before_consonant_sound;
+};
 
 const formatApproximateTime = (timeSeconds) => {
   const timeMinutes = parseInt(timeSeconds / 60, 10);
@@ -133,10 +133,9 @@ const formatApproximateTime = (timeSeconds) => {
   } else if (timeMinutes >= 50) {
     // If the time is between 50 and 60 minutes, describe it as "almost an hour"
     return `${strings.advb_almost} ${strings.time_h}`;
-  } else {
-    // Otherwise, describe the time in minutes
-    return `${strings.advb_about} ${util.format(strings.time_mm, timeMinutes)}`;
   }
+  // Otherwise, describe the time in minutes
+  return `${strings.advb_about} ${util.format(strings.time_mm, timeMinutes)}`;
 };
 
 const renderSentence = (template, dict) => toSentence(formatTemplate(template, dict));
@@ -220,7 +219,7 @@ class ChatMessageEvent extends StoryEvent {
     return formatTemplate(strings.story_chatmessage, {
       player: PlayerSpan(this.player),
       message: this.message,
-      said_verb: (this.message.charAt(this.message.length - 1) === '?') ? strings['story_chat_asked'] : strings['story_chat_said'],
+      said_verb: (this.message.charAt(this.message.length - 1) === '?') ? strings.story_chat_asked : strings.story_chat_said,
     });
   }
 }
@@ -694,7 +693,7 @@ const generateStory = (match) => {
   // Chat messages
   const chatMessageEvents = match.chat
     .filter(obj => obj.type === 'chat')
-    .map((obj) => new ChatMessageEvent(match, obj));
+    .map(obj => new ChatMessageEvent(match, obj));
   events = events.concat(chatMessageEvents);
 
   // Aegis pickups

--- a/src/components/Match/MatchStory.jsx
+++ b/src/components/Match/MatchStory.jsx
@@ -109,31 +109,30 @@ const toSentence = (content) => {
   return result;
 };
 
-const pluralize = (count, object, pluralization_override=null) => {
-  if (count == 1) {
-    return count + ' ' + object;
-  } else {
-    const pluralized_object = (pluralization_override !== null) ? pluralization_override : object + 's';
-    return count + ' ' + pluralized_object;
+const pluralize = (count, object, pluralizationOverride = null) => {
+  if (count === 1) {
+    return `${count} ${object}`;
   }
+  const pluralizedObject = (pluralizationOverride !== null) ? pluralizationOverride : `${object}s`;
+  return `${count} ${pluralizedObject}`;
 };
 
-const formatApproximateTime = (time_seconds) => {
-  const time_minutes = time_seconds / 60;
+const formatApproximateTime = (timeSeconds) => {
+  const timeMinutes = timeSeconds / 60;
 
   // If the time is at least one hour, describe it in hours
-  if (time_minutes > 60) {
-    const time_hours = time_seconds / (60 * 60);
-    return strings['advb_over'] + ' ' + pluralize(time_hours, strings['time_hs'])
+  if (timeMinutes > 60) {
+    const timeHours = timeSeconds / (60 * 60);
+    return `${strings.advb_over} ${pluralize(timeHours, strings.time_hs)}`;
   }
 
   // If the time is between 50 and 60 minutes, describe it as "almost an hour"
-  if (time_minutes >= 50) {
-    return strings['advb_almost'] + ' ' + strings['time_h'];
+  if (timeMinutes >= 50) {
+    return `${strings.advb_almost} ${strings.time_h}`;
   }
 
   // Otherwise, describe the time in minutes
-  return strings['advb_about'] + ' ' + pluralize(parseInt(time_seconds / 60), strings['time_ms']);
+  return `${strings.advb_about} ${pluralize(parseInt(timeSeconds / 60, 10), strings.time_ms)}`;
 };
 
 const renderSentence = (template, dict) => toSentence(formatTemplate(template, dict));
@@ -183,7 +182,7 @@ class IntroEvent extends StoryEvent {
         (window.localStorage && window.localStorage.getItem('localization')) || 'en-US',
         { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' }),
       region: strings[`region_${this.region}`],
-      duration_in_words: formatApproximateTime(this.match_duration_seconds)
+      duration_in_words: formatApproximateTime(this.match_duration_seconds),
     });
   }
 }
@@ -210,14 +209,14 @@ class ChatMessageEvent extends StoryEvent {
   constructor(match, obj) {
     super(obj.time + 70);
     this.type = obj.type;
-    this.player = match.players.find(player => player.player_slot == obj.player_slot);
+    this.player = match.players.find(player => player.player_slot === obj.player_slot);
     this.message = obj.key.trim();
   }
   format() {
     return formatTemplate(strings.story_chatmessage, {
       player: PlayerSpan(this.player),
       message: this.message,
-      said_verb: (this.message.charAt(this.message.length - 1) == '?') ? 'asked' : 'said'
+      said_verb: (this.message.charAt(this.message.length - 1) === '?') ? 'asked' : 'said',
     });
   }
 }
@@ -690,8 +689,8 @@ const generateStory = (match) => {
 
   // Chat messages
   const chatMessageEvents = match.chat
-    .filter(obj => obj.type == 'chat')
-    .map((obj, index) => new ChatMessageEvent(match, obj));
+    .filter(obj => obj.type === 'chat')
+    .map((obj) => new ChatMessageEvent(match, obj));
   events = events.concat(chatMessageEvents);
 
   // Aegis pickups

--- a/src/components/Match/MatchStory.jsx
+++ b/src/components/Match/MatchStory.jsx
@@ -125,7 +125,7 @@ const formatApproximateTime = (timeSeconds) => {
 
   // If the time is at least two hours, describe it in hours
   if (timeMinutes > 120) {
-    const timeHours = timeSeconds / (60 * 60);
+    const timeHours = parseInt(timeSeconds / (60 * 60), 10);
     return `${strings.advb_over} ${util.format(strings.time_hh, timeHours)}`;
   } else if (timeMinutes > 60 && timeMinutes <= 75) {
     // If the time is an hour to a quarter after, describe it as "over an hour"

--- a/src/components/Match/MatchStory.jsx
+++ b/src/components/Match/MatchStory.jsx
@@ -6,6 +6,7 @@ import {
   jsonFn,
   formatTemplate,
 } from 'utility';
+import util from 'util';
 import { IconRadiant, IconDire } from 'components/Icons';
 import heroes from 'dotaconstants/build/heroes.json';
 import items from 'dotaconstants/build/items.json';
@@ -109,14 +110,6 @@ const toSentence = (content) => {
   return result;
 };
 
-const pluralize = (count, object, pluralizationOverride = null) => {
-  if (count === 1) {
-    return `${count} ${object}`;
-  }
-  const pluralizedObject = (pluralizationOverride !== null) ? pluralizationOverride : `${object}s`;
-  return `${count} ${pluralizedObject}`;
-};
-
 const articleFor = (followingWord) => {
   // Whether we use a or an depends on the sound of the following word, but that's much hardder to detect programmatically,
   // so we're looking solely at vowel usage for now.
@@ -128,21 +121,22 @@ const articleFor = (followingWord) => {
 }
 
 const formatApproximateTime = (timeSeconds) => {
-  const timeMinutes = timeSeconds / 60;
+  const timeMinutes = parseInt(timeSeconds / 60, 10);
 
-  // If the time is at least one hour, describe it in hours
-  if (timeMinutes > 60) {
+  // If the time is at least two hours, describe it in hours
+  if (timeMinutes > 120) {
     const timeHours = timeSeconds / (60 * 60);
-    return `${strings.advb_over} ${pluralize(timeHours, strings.time_hs)}`;
-  }
-
-  // If the time is between 50 and 60 minutes, describe it as "almost an hour"
-  if (timeMinutes >= 50) {
+    return `${strings.advb_over} ${util.format(strings.time_hh, timeHours)}`;
+  } else if (timeMinutes > 60 && timeMinutes <= 75) {
+    // If the time is an hour to a quarter after, describe it as "over an hour"
+    return `${strings.advb_over} ${strings.time_h}`;
+  } else if (timeMinutes >= 50) {
+    // If the time is between 50 and 60 minutes, describe it as "almost an hour"
     return `${strings.advb_almost} ${strings.time_h}`;
+  } else {
+    // Otherwise, describe the time in minutes
+    return `${strings.advb_about} ${util.format(strings.time_mm, timeMinutes)}`;
   }
-
-  // Otherwise, describe the time in minutes
-  return `${strings.advb_about} ${pluralize(parseInt(timeSeconds / 60, 10), strings.time_ms)}`;
 };
 
 const renderSentence = (template, dict) => toSentence(formatTemplate(template, dict));
@@ -226,7 +220,7 @@ class ChatMessageEvent extends StoryEvent {
     return formatTemplate(strings.story_chatmessage, {
       player: PlayerSpan(this.player),
       message: this.message,
-      said_verb: (this.message.charAt(this.message.length - 1) === '?') ? 'asked' : 'said',
+      said_verb: (this.message.charAt(this.message.length - 1) === '?') ? strings['story_chat_asked'] : strings['story_chat_said'],
     });
   }
 }

--- a/src/components/Match/MatchStory.jsx
+++ b/src/components/Match/MatchStory.jsx
@@ -206,6 +206,22 @@ class FirstbloodEvent extends StoryEvent {
   }
 }
 
+class ChatMessageEvent extends StoryEvent {
+  constructor(match, obj) {
+    super(obj.time + 70);
+    this.type = obj.type;
+    this.player = match.players.find(player => player.player_slot == obj.player_slot);
+    this.message = obj.key;
+  }
+  format() {
+    return formatTemplate(strings.story_chatmessage, {
+      player: PlayerSpan(this.player),
+      message: this.message,
+      said_verb: (this.message.charAt(this.message.length - 1) == '?') ? 'asked' : 'said'
+    });
+  }
+}
+
 class AegisEvent extends StoryEvent {
   constructor(match, obj, index) {
     super(obj.time);
@@ -672,6 +688,11 @@ const generateStory = (match) => {
       (Array.isArray(killerLog) && killerLog[0] ? killerLog[0].key : null)));
   }
 
+  // Chat messages
+  const chatMessageEvents = match.chat
+    .filter(obj => obj.type == 'chat')
+    .map((obj, index) => new ChatMessageEvent(match, obj));
+  events = events.concat(chatMessageEvents);
 
   // Aegis pickups
   const aegisEvents = match.objectives

--- a/src/components/Match/MatchStory.jsx
+++ b/src/components/Match/MatchStory.jsx
@@ -109,6 +109,33 @@ const toSentence = (content) => {
   return result;
 };
 
+const pluralize = (count, object, pluralization_override=null) => {
+  if (count == 1) {
+    return count + ' ' + object;
+  } else {
+    const pluralized_object = (pluralization_override !== null) ? pluralization_override : object + 's';
+    return count + ' ' + pluralized_object;
+  }
+};
+
+const formatApproximateTime = (time_seconds) => {
+  const time_minutes = time_seconds / 60;
+
+  // If the time is at least one hour, describe it in hours
+  if (time_minutes > 60) {
+    const time_hours = time_seconds / (60 * 60);
+    return strings['advb_over'] + ' ' + pluralize(time_hours, strings['time_hs'])
+  }
+
+  // If the time is between 50 and 60 minutes, describe it as "almost an hour"
+  if (time_minutes >= 50) {
+    return strings['advb_almost'] + ' ' + strings['time_h'];
+  }
+
+  // Otherwise, describe the time in minutes
+  return strings['advb_about'] + ' ' + pluralize(parseInt(time_seconds / 60), strings['time_ms']);
+};
+
 const renderSentence = (template, dict) => toSentence(formatTemplate(template, dict));
 
 // Enumerates a list of items using the correct language syntax
@@ -146,6 +173,7 @@ class IntroEvent extends StoryEvent {
     this.game_mode = match.game_mode;
     this.region = match.region;
     this.date = new Date(match.start_time * 1000);
+    this.match_duration_seconds = match.duration;
   }
   format() {
     return formatTemplate(strings.story_intro, {
@@ -155,6 +183,7 @@ class IntroEvent extends StoryEvent {
         (window.localStorage && window.localStorage.getItem('localization')) || 'en-US',
         { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' }),
       region: strings[`region_${this.region}`],
+      duration_in_words: formatApproximateTime(this.match_duration_seconds)
     });
   }
 }

--- a/src/components/Match/MatchStory.jsx
+++ b/src/components/Match/MatchStory.jsx
@@ -149,6 +149,7 @@ class IntroEvent extends StoryEvent {
   }
   format() {
     return formatTemplate(strings.story_intro, {
+      game_mode_article: ['A', 'E', 'I', 'O', 'U'].includes(strings[`game_mode_${this.game_mode}`].charAt(0)) ? 'an' : 'a',
       game_mode: strings[`game_mode_${this.game_mode}`],
       date: this.date.toLocaleDateString(
         (window.localStorage && window.localStorage.getItem('localization')) || 'en-US',

--- a/src/components/Match/MatchStory.jsx
+++ b/src/components/Match/MatchStory.jsx
@@ -211,7 +211,7 @@ class ChatMessageEvent extends StoryEvent {
     super(obj.time + 70);
     this.type = obj.type;
     this.player = match.players.find(player => player.player_slot == obj.player_slot);
-    this.message = obj.key;
+    this.message = obj.key.trim();
   }
   format() {
     return formatTemplate(strings.story_chatmessage, {

--- a/src/components/Match/MatchStory.jsx
+++ b/src/components/Match/MatchStory.jsx
@@ -117,6 +117,16 @@ const pluralize = (count, object, pluralizationOverride = null) => {
   return `${count} ${pluralizedObject}`;
 };
 
+const articleFor = (followingWord) => {
+  // Whether we use a or an depends on the sound of the following word, but that's much hardder to detect programmatically,
+  // so we're looking solely at vowel usage for now.
+  if (['A', 'E', 'I', 'O', 'U'].includes(followingWord.charAt(0))) {
+    return strings['article_before_vowel_sound'];
+  } else {
+    return strings['article_before_consonant_sound'];
+  }
+}
+
 const formatApproximateTime = (timeSeconds) => {
   const timeMinutes = timeSeconds / 60;
 
@@ -176,7 +186,7 @@ class IntroEvent extends StoryEvent {
   }
   format() {
     return formatTemplate(strings.story_intro, {
-      game_mode_article: ['A', 'E', 'I', 'O', 'U'].includes(strings[`game_mode_${this.game_mode}`].charAt(0)) ? 'an' : 'a',
+      game_mode_article: articleFor(strings[`game_mode_${this.game_mode}`]),
       game_mode: strings[`game_mode_${this.game_mode}`],
       date: this.date.toLocaleDateString(
         (window.localStorage && window.localStorage.getItem('localization')) || 'en-US',

--- a/src/lang/en-US.json
+++ b/src/lang/en-US.json
@@ -1058,5 +1058,8 @@
 
   "advb_almost": "almost",
   "advb_over": "over",
-  "advb_about": "about"
+  "advb_about": "about",
+
+  "article_before_consonant_sound": "a",
+  "article_before_vowel_sound": "an"
 }

--- a/src/lang/en-US.json
+++ b/src/lang/en-US.json
@@ -526,7 +526,7 @@
 
   "story_invalid_template": "(invalid template)",
   "story_error": "An error occured while compiling the story for this match",
-  "story_intro": "on {date}, two teams decided to play a {game_mode} game of Dota 2 in {region}",
+  "story_intro": "on {date}, two teams decided to play {game_mode_article} {game_mode} game of Dota 2 in {region}",
   "story_invalid_hero": "Unrecognized Hero",
   "story_fullstop": ".",
   "story_list_2": "{1} and {2}",

--- a/src/lang/en-US.json
+++ b/src/lang/en-US.json
@@ -533,6 +533,7 @@
   "story_list_3": "{1}, {2}, and {3}",
   "story_list_n": "{i}, {rest}",
   "story_firstblood": "first blood was drawn when {killer} killed {victim} at {time}",
+  "story_chatmessage": "\"{message}\", {player} {said_verb}",
   "story_teamfight": "{winning_team} won a teamfight by trading {win_dead} for {lose_dead}, resulting in a net worth increase of {net_change}",
   "story_teamfight_none_dead": "{winning_team} won a teamfight by killing {lose_dead} without losing any heroes, resulting in a net worth increase of {net_change}",
   "story_lane_intro": "At 10 minutes into the game, the lanes had gone as follows:",

--- a/src/lang/en-US.json
+++ b/src/lang/en-US.json
@@ -526,7 +526,7 @@
 
   "story_invalid_template": "(invalid template)",
   "story_error": "An error occured while compiling the story for this match",
-  "story_intro": "on {date}, two teams decided to play {game_mode_article} {game_mode} game of Dota 2 in {region}",
+  "story_intro": "on {date}, two teams decided to play {game_mode_article} {game_mode} game of Dota 2 in {region}. Little did they know, the game would last {duration_in_words}",
   "story_invalid_hero": "Unrecognized Hero",
   "story_fullstop": ".",
   "story_list_2": "{1} and {2}",
@@ -751,8 +751,10 @@
   "time_s": "a second",
   "time_ss": "%d seconds",
   "time_m": "a minute",
+  "time_ms": "minute",
   "time_mm": "%d minutes",
   "time_h": "an hour",
+  "time_hs": "hour",
   "time_hh": "%d hours",
   "time_d": "a day",
   "time_dd": "%d days",
@@ -1051,6 +1053,9 @@
 
   "chatwheel_108": "It's a disastah!",
   "chatwheel_109": "走好, 不送",
-  "chatwheel_110": "Это. Просто. Нечто."
+  "chatwheel_110": "Это. Просто. Нечто.",
 
+  "advb_almost": "almost",
+  "advb_over": "over",
+  "advb_about": "about"
 }

--- a/src/lang/en-US.json
+++ b/src/lang/en-US.json
@@ -565,6 +565,9 @@
   "story_predicted_victory_empty": "No one",
   "story_networth_diff": "{percent}% / {gold} Diff",
 
+  "story_chat_asked": "asked",
+  "story_chat_said": "said",
+
   "tab_overview": "Overview",
   "tab_matches": "Matches",
   "tab_heroes": "Heroes",
@@ -752,10 +755,8 @@
   "time_s": "a second",
   "time_ss": "%d seconds",
   "time_m": "a minute",
-  "time_ms": "minute",
   "time_mm": "%d minutes",
   "time_h": "an hour",
-  "time_hs": "hour",
   "time_hh": "%d hours",
   "time_d": "a day",
   "time_dd": "%d days",


### PR DESCRIPTION
Hey guys, just wanted to include a few small updates to `MatchStory`. I'm tempted to make more, but I also recognize a lot of changes are preferential, so I'll keep PRs small to enable picking and choosing which changes we want. 

This PR:

1. Switches between 'a' and 'an' before game types in the `IntroEvent`, so we'll see **an** All Draft and **a** Captain's Draft.
2. Includes the final length of the match in the game intro, so readers know about how long to expect the match to last. 
  *- This also approximates the game time to either "about X minutes", "almost an hour", and "over X hours" to read nicely.
3. Adds a new `ChatMessageEvent` to include dialogue from players in the story, which makes for some fun interactions like seeing chat after a first blood, or seeing everyone's "gg"s after the match ends.

IMO, adding dialogue to the match story makes it read more like a story with characters rather than a narrative of the game's events. 

Some screenshots:

![2017-08-27-210311_648x109_scrot](https://user-images.githubusercontent.com/538235/29753157-88401d6c-8b6b-11e7-9cff-bf7243cf1bfe.png)

![2017-08-27-211746_512x149_scrot](https://user-images.githubusercontent.com/538235/29753247-6633d176-8b6d-11e7-82f0-c78e34a93344.png)

![2017-08-27-211211_918x173_scrot](https://user-images.githubusercontent.com/538235/29753209-6a9027a2-8b6c-11e7-9fd5-8038503fb1dd.png)

![2017-08-27-210624_568x207_scrot](https://user-images.githubusercontent.com/538235/29753184-200fe3a2-8b6c-11e7-9e79-a2cf88cce560.png)

cc @mdiller @howardchung 