### PR TITLE
1040 - Filter Siltbreaker matches from averages

### DIFF
--- a/src/components/Player/Pages/Overview/Overview.jsx
+++ b/src/components/Player/Pages/Overview/Overview.jsx
@@ -22,6 +22,8 @@ const MAX_HEROES_ROWS = 10;
 const MAX_PEERS_ROWS = 5;
 
 const Overview = ({
+  validRecentMatches,
+  numValidRecentMatches,
   matchesData,
   matchesLoading,
   matchesError,
@@ -37,12 +39,12 @@ const Overview = ({
     <Container
       title={strings.heading_avg_and_max}
       titleTo={`/players/${playerId}/records`}
-      subtitle={util.format(strings.subheading_avg_and_max, MAX_MATCHES_ROWS)}
+      subtitle={util.format(strings.subheading_avg_and_max, numValidRecentMatches)}
       className={sumStyles.summaryContainer}
       loading={matchesLoading}
       error={matchesError}
     >
-      <SummOfRecMatches matchesData={matchesData} />
+      <SummOfRecMatches matchesData={validRecentMatches} />
     </Container>
     <Container
       title={strings.heading_matches}
@@ -57,6 +59,7 @@ const Overview = ({
         maxRows={MAX_MATCHES_ROWS}
       />
     </Container>
+
     <div className={styles.heroesContainer}>
       <Container
         title={strings.heading_peers}
@@ -70,6 +73,7 @@ const Overview = ({
           maxRows={MAX_PEERS_ROWS}
         />
       </Container>
+
       <Container
         title={strings.heading_heroes}
         titleTo={`/players/${playerId}/heroes`}
@@ -114,10 +118,26 @@ const mergeHeroGuides = (heroes, heroGuides) => heroes.map(hero => ({
   pvgnaGuide: heroGuides[hero.hero_id],
 }));
 
+/**
+ * Get the number of recent matches, filtering out Siltbreaker matches
+ */
+const countValidRecentMatches = matches => matches.filter(match => match.game_mode !== 19).length;
+
+/**
+ * Get the recent matches, filtering out Siltbreaker matches
+ *
+ * XXX - this could be switched to use playerMatches while specifying the
+ * desired fields in order to request >20 matches and filter down to 20 matches.
+ */
+const getValidRecentMatches = matches => matches.filter(match => match.game_mode !== 19)
+  .slice(0, MAX_MATCHES_ROWS);
+
 const mapStateToProps = state => ({
   matchesData: state.app.playerRecentMatches.data,
   matchesLoading: state.app.playerRecentMatches.loading,
   matchesError: state.app.playerRecentMatches.error,
+  validRecentMatches: getValidRecentMatches(state.app.playerRecentMatches.data),
+  numValidRecentMatches: countValidRecentMatches(state.app.playerRecentMatches.data),
   heroesData: mergeHeroGuides(state.app.playerHeroes.data, state.app.pvgnaGuides.data),
   heroesLoading: state.app.playerHeroes.loading,
   heroesError: state.app.playerHeroes.error,

--- a/src/components/Player/Pages/Overview/Summary.jsx
+++ b/src/components/Player/Pages/Overview/Summary.jsx
@@ -36,17 +36,15 @@ const SummOfRecMatches = ({ matchesData }) => {
 
   const numRows = Math.min(MAX_MATCHES_ROWS, matchesData.length);
 
-  for (let i = 0; i < numRows; i += 1) {
-    dataKeys.map((key) => {
+  matchesData.forEach((match) => {
+    dataKeys.forEach((key) => {
       if (key === 'wins') {
-        data.wins.push(matchesData[i].radiant_win === isRadiant(matchesData[i].player_slot));
+        data.wins.push(match.radiant_win === isRadiant(match.player_slot));
       } else {
-        data[key].push(matchesData[i][key]);
+        data[key].push(match[key]);
       }
-
-      return null;
     });
-  }
+  });
 
   dataKeys.map((key) => {
     if (key !== 'wins') {


### PR DESCRIPTION
fixes #1040 

Only pass non-siltbreaker matches from Overview to Summary

This could be updated to use the getPlayerMatches endpoint instead
of getPlayerRecentMatches if we specify the fields we want to
display averages on (and probably some upper bound of matches we
want to retrieve.)