### PR TITLE
Fix approximate time in match story

### DIFF
--- a/src/components/Match/MatchStory.jsx
+++ b/src/components/Match/MatchStory.jsx
@@ -131,7 +131,7 @@ const formatApproximateTime = (timeSeconds) => {
   } else if (timeMinutes > 60 && timeMinutes <= 120) {
     // If the time is an hour to a quarter after, describe it as "over an hour"
     return `${strings.advb_over} ${strings.time_h}`;
-  } else if (timeMinutes >= 50) {
+  } else if (timeMinutes >= 50 && timeMinutes < 60) {
     // If the time is between 50 and 60 minutes, describe it as "almost an hour"
     return `${strings.advb_almost} ${strings.time_h}`;
   }


### PR DESCRIPTION
Previously,

* Matches longer than 120 minutes that fell through the if statement would fall into the "almost an hour" clause

Now,

* Only matches between 50 and 60 minutes will fall into "almost an hour"
* Matches that last between 60.0 and <61.0 minutes will be estimated with "about 60 minutes"
* Matches longer than 2 hours will be estimated with "about X minutes"