### PR TITLE
Chatwheel Filtering

### DIFF
--- a/src/components/Match/Chat/Chat.jsx
+++ b/src/components/Match/Chat/Chat.jsx
@@ -51,7 +51,7 @@ class Chat extends React.Component {
       radiant: true,
       dire: true,
       text: true,
-      phrases: true,
+      phrases: false,
       audio: true,
       all: true,
       allies: true,


### PR DESCRIPTION
Semi-recently we excluded non-sound chatwheel phrases from the match json blob because they were cluttering up the chat tab. This PR filters them out in the ui instead, meaning any services using the opendota api will still be able to see the chatwheel in the chat.