### PR TITLE
Fix <img> alt text in Story Mode

### DIFF
--- a/src/components/Match/MatchStory.jsx
+++ b/src/components/Match/MatchStory.jsx
@@ -29,7 +29,7 @@ const GoldSpan = amount => (
     <img
       width="25px"
       height="17px"
-      alt={`${amount.toLocaleString()} gold`}
+      alt={'gold'}
       src={`${API_HOST}/apps/dota2/images/tooltips/gold.png`}
       style={{ marginLeft: '3px' }}
     />
@@ -63,7 +63,7 @@ const PlayerSpan = (player) => {
             ? `${API_HOST}${heroes[player.hero_id].icon}`
             : '/assets/images/blank-1x1.gif'
           }
-          alt={heroName}
+          alt=""
         />
         {heroName}
       </span>

--- a/src/components/Match/MatchStory.jsx
+++ b/src/components/Match/MatchStory.jsx
@@ -29,7 +29,7 @@ const GoldSpan = amount => (
     <img
       width="25px"
       height="17px"
-      alt={'gold'}
+      alt={' gold'}
       src={`${API_HOST}/apps/dota2/images/tooltips/gold.png`}
       style={{ marginLeft: '3px' }}
     />

--- a/src/components/Match/MatchStory.jsx
+++ b/src/components/Match/MatchStory.jsx
@@ -29,7 +29,7 @@ const GoldSpan = amount => (
     <img
       width="25px"
       height="17px"
-      alt={' gold'}
+      alt={` ${strings.story_gold}`}
       src={`${API_HOST}/apps/dota2/images/tooltips/gold.png`}
       style={{ marginLeft: '3px' }}
     />

--- a/src/lang/en-US.json
+++ b/src/lang/en-US.json
@@ -566,6 +566,7 @@
   "story_predicted_victory": "{players} predicted {team} would win",
   "story_predicted_victory_empty": "No one",
   "story_networth_diff": "{percent}% / {gold} Diff",
+  "story_gold": "gold",
 
   "story_chat_asked": "asked",
   "story_chat_said": "said",


### PR DESCRIPTION
This should fix the problem described in Issue #1171 by removing the alt text on the hero icons and by changing the alt text on the gold icon from `9999 gold` to ` gold`.
