### PR TITLE
Fixed sort function name in Table state

### DIFF
--- a/src/components/Table/Table.jsx
+++ b/src/components/Table/Table.jsx
@@ -45,7 +45,7 @@ const initialState = {
   currentPage: 0,
   sortState: '',
   sortField: '',
-  sortFnc: f => f,
+  sortFn: f => f,
 };
 
 class Table extends React.Component {
@@ -99,14 +99,14 @@ class Table extends React.Component {
       paginated,
       pageLength = 20,
     } = this.props;
-    const { sortState, sortField, sortFnc, currentPage } = this.state;
+    const { sortState, sortField, sortFn, currentPage } = this.state;
     const dataLength = this.props.data.length;
     let data = this.props.data;
     if (maxRows && maxRows <= dataLength) {
       data = data.slice(0, maxRows);
     }
     if (sortField) {
-      data = defaultSort(data, sortState, sortField, sortFnc);
+      data = defaultSort(data, sortState, sortField, sortFn);
     }
     if (paginated) {
       data = data.slice(currentPage * pageLength, (currentPage + 1) * pageLength);


### PR DESCRIPTION
Fixes #1206 

Sort was not working on tables. (e.g. match overview player table)
A refactor changed `sortFn` to `sortFnc` in some cases. Reverted the changes to have everything as `sortFn` again. This fixes the sorting bug.