### PR TITLE
Graph range fix, MMR brush implemented

### DIFF
--- a/src/components/Visualizations/Graph/MMRGraph.jsx
+++ b/src/components/Visualizations/Graph/MMRGraph.jsx
@@ -9,53 +9,66 @@ import {
   LineChart,
   CartesianGrid,
   Legend,
-  Label, ResponsiveContainer,
+  Label, ResponsiveContainer, Brush,
 } from 'recharts';
 import constants from 'components/constants';
+import styled from 'styled-components';
+
+const StyledGraphArea = styled.div`
+user-select: none;
+`;
 
 const formatXTick = (time) => {
   const date = new Date(time);
   return `${date.getFullYear()}/${date.getMonth() + 1}`;
 };
+const formatXTickDetailed = (time) => {
+  const date = new Date(time);
+  return `${date.toLocaleString()}`;
+};
 
 const MMRGraph = ({ columns }) => (
-  <ResponsiveContainer width="100%" height={400}>
-    <LineChart
-      data={columns}
-      margin={{
+  <StyledGraphArea>
+    <ResponsiveContainer width="100%" height={400}>
+      <LineChart
+        data={columns}
+        margin={{
         top: 5, right: 30, left: 30, bottom: 5,
       }}
-    >
-      <XAxis dataKey="time" interval={49} tickFormatter={formatXTick}>
-        <Label value={strings.th_time} position="insideTopRight" />
-      </XAxis>
-      <YAxis />
-      <CartesianGrid
-        stroke="#505050"
-        strokeWidth={1}
-        opacity={0.5}
-      />
+      >
+        <XAxis dataKey="time" interval={49} tickFormatter={formatXTick}>
+          <Label value={strings.th_time} position="insideTopRight" />
+        </XAxis>
+        <YAxis type="number" domain={['dataMin - 150', 'dataMax + 150']} />
+        <CartesianGrid
+          stroke="#505050"
+          strokeWidth={1}
+          opacity={0.5}
+        />
 
-      <Tooltip
-        wrapperStyle={{ backgroundColor: constants.darkPrimaryColor, border: 'none' }}
-      />
-      <Line
-        dot={false}
-        dataKey="solo_competitive_rank"
-        stroke="#66BBFF"
-        strokeWidth={2}
-        name={strings.th_solo_mmr}
-      />
-      <Line
-        dot={false}
-        dataKey="competitive_rank"
-        stroke="#FF4C4C"
-        strokeWidth={2}
-        name={strings.th_party_mmr}
-      />
-      <Legend />
-    </LineChart>
-  </ResponsiveContainer>
+        <Tooltip
+          wrapperStyle={{ backgroundColor: constants.darkPrimaryColor, border: 'none' }}
+          labelFormatter={formatXTickDetailed}
+        />
+        <Line
+          dot={false}
+          dataKey="solo_competitive_rank"
+          stroke="#66BBFF"
+          strokeWidth={2}
+          name={strings.th_solo_mmr}
+        />
+        <Line
+          dot={false}
+          dataKey="competitive_rank"
+          stroke="#FF4C4C"
+          strokeWidth={2}
+          name={strings.th_party_mmr}
+        />
+        <Legend verticalAlign="top" />
+        <Brush dataKey="time" height={40} stroke={constants.primaryLinkColor} fill={constants.darkPrimaryColor} tickFormatter={formatXTick} />
+      </LineChart>
+    </ResponsiveContainer>
+  </StyledGraphArea>
 );
 
 MMRGraph.propTypes = {

--- a/src/components/Visualizations/Graph/TrendGraph.jsx
+++ b/src/components/Visualizations/Graph/TrendGraph.jsx
@@ -72,7 +72,18 @@ const TooltipStylesDiv = styled.div`
     font-size: ${constants.fontSizeCommon};
   }
 `;
-
+const getHeroImg = (data) => {
+  try {
+    return (<img
+      className="heroImg"
+      src={`${process.env.REACT_APP_API_HOST}${heroes[data.hero_id]
+    .img}`}
+      alt=""
+    />);
+  } catch (e) {
+    return <div />;
+  }
+};
 const TrendTooltipContent = ({ payload, name }) => {
   const data = (payload[0] || {}).payload;
   if (data) {
@@ -104,12 +115,7 @@ const TrendTooltipContent = ({ payload, name }) => {
               )}
             </div>
             <div className="hero">
-              <img
-                className="heroImg"
-                src={`${process.env.REACT_APP_API_HOST}${heroes[data.hero_id]
-                  .img}`}
-                alt=""
-              />
+              { getHeroImg(data)}
             </div>
           </div>
         </div>
@@ -137,7 +143,7 @@ const TrendGraph = ({ columns, name }) => (
       <XAxis interval={49}>
         <Label value="" position="insideTopRight" />
       </XAxis>
-      <YAxis />
+      <YAxis domain={['auto', 'auto']} />
       <CartesianGrid stroke="#505050" strokeWidth={1} opacity={0.5} />
 
       <Tooltip content={<TrendTooltipContent name={name} />} />


### PR DESCRIPTION
#### Implemented graph range
- MMR graph set to minimal MMR - 150 and maximal +150
- Fixed Date displayed on tooltip to localdatestring
- Fixed IMG of hero occasionally crashing (could not reproduce so i put it in try catch and return empty div when fail, it probably happen when you move fast so img fetch is interrupted with another)
- Trends set to auto - auto (will start and end how recharts thinks its the best )
##### Experimental Brush on MMR
- selector to select range for date in mmr graph (kinda zoom functionality) on local machine its performance heavy when selecting so if it will be issue it can be removed.

If i forgot some graphs let me know.