### PR TITLE
Stack kills/damage tables in mobile

### DIFF
--- a/src/components/Match/StyledMatch.jsx
+++ b/src/components/Match/StyledMatch.jsx
@@ -167,8 +167,13 @@ export const StyledBackpack = styled.div`
 `;
 export const StyledFlexContainer = styled.div`
   display: flex;
+  flex-direction: column;
   flex-wrap: wrap;
   overflow: auto;
+
+  @media only screen and (min-width: 800px) {
+    flex-direction: row;
+  }
 `;
 export const StyledFlexElement = styled.div`
   flex: 1;


### PR DESCRIPTION
For https://github.com/odota/ui/issues/1256

On mobile:
![image](https://user-images.githubusercontent.com/934937/31530372-976b6d34-b012-11e7-9d28-07d3ed727e2f.png)

On desktop still the same:
![image](https://user-images.githubusercontent.com/934937/31530349-6c414fca-b012-11e7-8657-215e86df945f.png)
