### PR TITLE
Fix #1304 Loading Spinners for Index Pages

### DIFF
--- a/src/components/Heroes/index.jsx
+++ b/src/components/Heroes/index.jsx
@@ -70,7 +70,7 @@ class RequestLayer extends React.Component {
     const heroTabs = [{
       name: strings.hero_pro_tab,
       key: 'pro',
-      content: (data, _columns) => (
+      content: (data, _columns, loading) => (
         <div>
           <Heading
             title={strings.hero_pro_heading}
@@ -78,13 +78,13 @@ class RequestLayer extends React.Component {
             icon=""
             twoLine
           />
-          <Table data={data} columns={_columns} />
+          <Table data={data} columns={_columns} loading={loading} />
         </div>),
       route: '/heroes/pro',
     }, {
       name: strings.hero_public_tab,
       key: 'public',
-      content: (data, _columns) => (
+      content: (data, _columns, loading) => (
         <div>
           <Heading
             title={strings.hero_public_heading}
@@ -92,7 +92,7 @@ class RequestLayer extends React.Component {
             icon=""
             twoLine
           />
-          <Table data={data} columns={_columns} />
+          <Table data={data} columns={_columns} loading={loading} />
         </div>),
       route: '/heroes/public',
     }];
@@ -103,14 +103,13 @@ class RequestLayer extends React.Component {
     return (
       <div>
         <Helmet title={strings.header_heroes} />
-        {!loading &&
         <div>
           <TabBar
             info={route}
             tabs={heroTabs}
           />
-          {tab && tab.content(processedData, columns[route])}
-        </div>}
+          {tab && tab.content(processedData, columns[route], loading)}
+        </div>
       </div>);
   }
 }

--- a/src/components/Matches/index.jsx
+++ b/src/components/Matches/index.jsx
@@ -93,7 +93,7 @@ const matchTabs = [{
   key: 'pro',
   content: propsPar => (
     <div>
-      <Table data={propsPar.proData} columns={matchesColumns} />
+      <Table data={propsPar.proData} columns={matchesColumns} loading={propsPar.loading} />
     </div>),
   route: '/matches/pro',
 }, {
@@ -101,7 +101,7 @@ const matchTabs = [{
   key: 'highMmr',
   content: propsPar => (
     <div>
-      <Table data={propsPar.publicData} columns={publicMatchesColumns} />
+      <Table data={propsPar.publicData} columns={publicMatchesColumns} loading={propsPar.loading} />
     </div>),
   route: '/matches/highMmr',
 }, {
@@ -109,7 +109,7 @@ const matchTabs = [{
   key: 'lowMmr',
   content: propsPar => (
     <div>
-      <Table data={propsPar.publicData} columns={publicMatchesColumns} />
+      <Table data={propsPar.publicData} columns={publicMatchesColumns} loading={propsPar.loading} />
     </div>),
   route: '/matches/lowMmr',
 }];

--- a/src/components/Records/index.jsx
+++ b/src/components/Records/index.jsx
@@ -36,7 +36,11 @@ const tabs = fields.map(field => ({
   key: field,
   content: propsPar => (
     <Container>
-      <Table data={propsPar.data.map((element, index) => ({ ...element, rank: index + 1 }))} columns={matchesColumns(field)} />
+      <Table
+        data={propsPar.data.map((element, index) => ({ ...element, rank: index + 1 }))}
+        columns={matchesColumns(field)}
+        loading={propsPar.loading}
+      />
     </Container>),
   route: `/records/${field}`,
 }));

--- a/src/components/Teams/index.jsx
+++ b/src/components/Teams/index.jsx
@@ -45,11 +45,12 @@ class RequestLayer extends React.Component {
     this.props.dispatchTeams();
   }
   render() {
+    const { loading } = this.props;
     return (
       <div>
         <Helmet title={strings.header_teams} />
         <Heading title={strings.heading_team_elo_rankings} subtitle={strings.subheading_team_elo_rankings} />
-        <Table columns={columns} data={this.props.data.slice(0, 100)} />
+        <Table columns={columns} data={this.props.data.slice(0, 100)} loading={loading} />
       </div>);
   }
 }
@@ -57,6 +58,7 @@ class RequestLayer extends React.Component {
 RequestLayer.propTypes = {
   dispatchTeams: PropTypes.string,
   data: PropTypes.string,
+  loading: PropTypes.bool,
 };
 
 const mapStateToProps = state => ({


### PR DESCRIPTION
Readds loading spinners for Matches/Teams/Heroes/Records by properly passing the loading prop to the Table component.