### PR TITLE
Fixed styling for networth bar for large and small screen sizes

### DIFF
--- a/src/components/Match/StyledMatch.jsx
+++ b/src/components/Match/StyledMatch.jsx
@@ -247,6 +247,7 @@ export const StyledStoryNetWorthBar = styled.div`
 }
 `;
 export const StyledStoryNetWorthText = styled.div`
+  position: relative;
   display: flex;
   text-align: center;
   ${props => (props.color ? `background-color:${props.color}` : '')};
@@ -260,6 +261,10 @@ export const StyledStoryNetWorthText = styled.div`
   > div:nth-child(2) {
     position: absolute;
     transform: translateX(-50%);
+
+    @media only screen and (max-width: 768px) {
+      display: none;
+    }
   }
 `;
 export const StyledLogFilterForm = styled.div`


### PR DESCRIPTION
fixes #1306 

The text in the middle now maintains its correct position on larger screens
The text in the middle now goes away on smaller screens.