### PR TITLE
Hide home page login button if user is logged in

### DIFF
--- a/src/components/Home/Buttons.jsx
+++ b/src/components/Home/Buttons.jsx
@@ -7,13 +7,6 @@ import strings from 'lang';
 import { IconSteam } from 'components/Icons';
 import { ButtonsDiv } from './Styled';
 
-const mapStateToProps = (state) => {
-  const { data } = state.app.metadata;
-  return {
-    user: data.user,
-  };
-};
-
 const Buttons = ({ user }) => (
   <ButtonsDiv>
     {
@@ -54,13 +47,11 @@ Buttons.propTypes = {
   user: PropTypes.shape({}),
 };
 
-class RequestLayer extends React.Component {
-  componentWillUpdate() {
-  }
+const mapStateToProps = (state) => {
+  const { data } = state.app.metadata;
+  return {
+    user: data.user,
+  };
+};
 
-  render() {
-    return <Buttons {...this.props} />;
-  }
-}
-
-export default connect(mapStateToProps, null)(RequestLayer);
+export default connect(mapStateToProps, null)(Buttons);

--- a/src/components/Home/Buttons.jsx
+++ b/src/components/Home/Buttons.jsx
@@ -1,19 +1,31 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
+import PropTypes from 'prop-types';
 import FlatButton from 'material-ui/FlatButton';
+import { connect } from 'react-redux';
 import strings from 'lang';
 import { IconSteam } from 'components/Icons';
 import { ButtonsDiv } from './Styled';
 
-export default () => (
+const mapStateToProps = (state) => {
+  const { data } = state.app.metadata;
+  return {
+    user: data.user,
+  };
+};
+
+const Buttons = ({ user }) => (
   <ButtonsDiv>
-    <div>
-      <FlatButton
-        label={<span className="label"><b>{strings.home_login}</b> {strings.home_login_desc}</span>}
-        icon={<IconSteam />}
-        href={`${process.env.REACT_APP_API_HOST}/login`}
-      />
-    </div>
+    {
+      !user &&
+      <div>
+        <FlatButton
+          label={<span className="label"><b>{strings.home_login}</b> {strings.home_login_desc}</span>}
+          icon={<IconSteam />}
+          href={`${process.env.REACT_APP_API_HOST}/login`}
+        />
+      </div>
+    }
     <div className="bottomButtons">
       <div>
         <FlatButton
@@ -37,3 +49,18 @@ export default () => (
     </div>
   </ButtonsDiv>
 );
+
+Buttons.propTypes = {
+  user: PropTypes.shape({}),
+};
+
+class RequestLayer extends React.Component {
+  componentWillUpdate() {
+  }
+
+  render() {
+    return <Buttons {...this.props} />;
+  }
+}
+
+export default connect(mapStateToProps, null)(RequestLayer);


### PR DESCRIPTION
If the user is already logged in, the "Login for automatic replay parsing" button disappears.
Before:

![](https://dl.dropboxusercontent.com/s/o43z1fhplgu1q6r/firefox_2017-11-16_23-42-02.png)

After:
![](https://dl.dropboxusercontent.com/s/ktiyy1oek3rid3j/firefox_2017-11-16_23-39-12.png)