### PR TITLE
Handle new heroes in combat and log tabs

### DIFF
--- a/src/components/Match/CastTable.jsx
+++ b/src/components/Match/CastTable.jsx
@@ -63,7 +63,7 @@ const CastTable = ({
   <Tabs>
     {match.players.map(p =>
       (
-        <Tab key={p.player_slot} icon={<img src={`${process.env.REACT_APP_API_HOST}${heroes[p.hero_id].img}`} height={30} alt="" />}>
+        <Tab key={p.player_slot} icon={<img src={heroes[p.hero_id] && process.env.REACT_APP_API_HOST + heroes[p.hero_id].img} height={30} alt="" />}>
           <Table
             data={getCastArray(p)}
             columns={castsColumns}

--- a/src/components/Match/CrossTable.jsx
+++ b/src/components/Match/CrossTable.jsx
@@ -65,7 +65,7 @@ const CrossTable = ({
           let ptotal2 = 0;
 
           match.players.slice(match.players.length / 2, match.players.length).forEach((player2) => {
-            const hero2 = heroes[player2.hero_id];
+            const hero2 = heroes[player2.hero_id] || {};
             ptotal1 += (player[field1] && hero2.name in player[field1]) ? player[field1][hero2.name] : 0;
             ptotal2 += (player[field2] && hero2.name in player[field2]) ? player[field2][hero2.name] : 0;
           });
@@ -98,7 +98,7 @@ const CrossTable = ({
           let ptotal2 = 0;
 
           match.players.slice(0, match.players.length / 2).forEach((player2) => {
-            const hero2 = heroes[player2.hero_id];
+            const hero2 = heroes[player2.hero_id] || {};
             ptotal1 += (player[field1] && hero2.name in player[field1]) ? player[field1][hero2.name] : 0;
             ptotal2 += (player[field2] && hero2.name in player[field2]) ? player[field2][hero2.name] : 0;
           });
@@ -123,9 +123,9 @@ const CrossTable = ({
           let direTotal = 0;
 
           match.players.slice(match.players.length / 2, match.players.length).forEach((player) => {
-            const hero = heroes[player.hero_id];
+            const hero = heroes[player.hero_id] || {};
             match.players.slice(0, match.players.length / 2).forEach((player2) => {
-              const hero2 = heroes[player2.hero_id];
+              const hero2 = heroes[player2.hero_id] || {};
               radiantTotal += (player2[field1] && hero.name in player2[field1]) ? player2[field1][hero.name] : 0;
               direTotal += (player[field1] && hero2.name in player[field1]) ? player[field1][hero2.name] : 0;
             });

--- a/src/components/Match/MatchLog.jsx
+++ b/src/components/Match/MatchLog.jsx
@@ -138,7 +138,7 @@ class MatchLog extends React.Component {
       { text: strings.heading_runes, value: 2 },
     ];
     this.playersSource = this.props.match.players.map((player, index) => ({
-      text: heroes[player.hero_id].localized_name || strings.general_no_hero,
+      text: heroes[player.hero_id] ? heroes[player.hero_id].localized_name : strings.general_no_hero,
       value: index,
     }));
 

--- a/src/components/Match/MatchStory.jsx
+++ b/src/components/Match/MatchStory.jsx
@@ -60,7 +60,7 @@ const PlayerSpan = (player) => {
       >
         <img
           src={heroes[player.hero_id]
-            ? `${process.env.REACT_APP_API_HOST}${heroes[player.hero_id].icon}`
+            ? process.env.REACT_APP_API_HOST + heroes[player.hero_id].icon
             : '/assets/images/blank-1x1.gif'
           }
           alt=""
@@ -578,9 +578,9 @@ class TeamfightEvent extends StoryEvent {
       winning_team: TeamSpan(this.winning_team),
       net_change: GoldSpan(this.gold_delta),
       win_dead: formatList(this.win_dead.map(death => (
-        death.count === 1 ? new PlayerSpan(death.player) : [new PlayerSpan(death.player), `(x${death.count})`]))),
+        death.count === 1 ? PlayerSpan(death.player) : [PlayerSpan(death.player), `(x${death.count})`]))),
       lose_dead: formatList(this.lose_dead.map(death => (
-        death.count === 1 ? new PlayerSpan(death.player) : [new PlayerSpan(death.player), `(x${death.count})`]))),
+        death.count === 1 ? PlayerSpan(death.player) : [PlayerSpan(death.player), `(x${death.count})`]))),
     })];
     if (this.during_events.length > 0) {
       formatted = formatted.concat(renderSentence(

--- a/src/components/Match/Overview/PicksBans.jsx
+++ b/src/components/Match/Overview/PicksBans.jsx
@@ -71,7 +71,7 @@ const PicksBans = ({ data }) => (
       {data.map(pb => (
         <section key={pb.order}>
           <img
-            src={`${process.env.REACT_APP_API_HOST}${heroes[pb.hero_id].img}`}
+            src={heroes[pb.hero_id] && process.env.REACT_APP_API_HOST + heroes[pb.hero_id].img}
             alt=""
             className="image"
             data-isPick={pb.is_pick}

--- a/src/components/Player/TableFilterForm/TableFilter.config.js
+++ b/src/components/Player/TableFilterForm/TableFilter.config.js
@@ -8,7 +8,7 @@ import strings from 'lang';
 // they are probably built like this to allow map key access but it would be nice if I didn't
 // have to convert them all into arrays.
 export const heroList = Object.keys(heroes).map(id => ({
-  text: heroes[id].localized_name,
+  text: heroes[id] && heroes[id].localized_name,
   value: id,
 })).sort((a, b) => a.text.localeCompare(b.text));
 export const laneList = Object.keys(strings)

--- a/src/components/Visualizations/Graph/MatchGraph.jsx
+++ b/src/components/Visualizations/Graph/MatchGraph.jsx
@@ -188,7 +188,7 @@ class PlayersGraph extends React.Component {
               {match.players.map((player) => {
                 const hero = heroes[player.hero_id] || {};
                 const playerColor = playerColors[player.player_slot];
-                const isSelected = (hoverHero === heroes[player.hero_id].localized_name);
+                const isSelected = heroes[player.hero_id] && (hoverHero === heroes[player.hero_id].localized_name);
                 const opacity = (!hoverHero || isSelected) ? 1 : 0.25;
                 const stroke = (isSelected) ? 4 : 2;
                 return (<Line


### PR DESCRIPTION
fixes #1294 

There was an issue in MatchStory.jsx in the Teamfight event where "PlayerSpan" was instanciated with "new" operator, causing the return of an empty object (the object constructed by new).
fix to #1294